### PR TITLE
Central Tavern/Inn Overhaul

### DIFF
--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -1077,9 +1077,6 @@
 /obj/machinery/light/rogue/lanternpost,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield)
-"aov" = (
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town/tavern)
 "aoQ" = (
 /obj/structure/spacevine,
 /turf/open/floor/rogue/dirt/ambush,
@@ -1154,8 +1151,13 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
 "aCU" = (
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/bath)
+/obj/structure/fluff/walldeco/innsign{
+	pixel_x = 32;
+	name = "The Dark Oak";
+	desc = "The inn of the Frozen Summit outpost. Where tales come to begin and die."
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/rtfield)
 "aEv" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -1176,16 +1178,6 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave)
-"aHs" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 5
-	},
-/turf/open/floor/rogue/grasscold,
-/area/rogue/indoors/town/tavern)
 "aIP" = (
 /obj/item/reagent_containers/food/snacks/crow{
 	dir = 1
@@ -1236,12 +1228,6 @@
 /obj/item/rogue/instrument/harp,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/tavern)
-"aQU" = (
-/obj/structure/flora/newbranch/connector{
-	dir = 8
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/town/tavern)
 "aRe" = (
 /obj/structure/stairs{
 	icon_state = "stairs";
@@ -1268,6 +1254,17 @@
 "aTl" = (
 /turf/closed/wall/mineral/rogue/decostone/end,
 /area/rogue/outdoors/rtfield)
+"aVf" = (
+/obj/structure/closet/crate/chest/neu_iron,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/obj/item/reagent_containers/glass/bottle/rogue/whitewine,
+/obj/item/reagent_containers/glass/bottle/rogue/redwine,
+/obj/item/reagent_containers/glass/bottle/rogue/wine/sourwine,
+/obj/item/reagent_containers/glass/bottle/rogue/wine/sourwine,
+/obj/item/reagent_containers/glass/bottle/rogue/wine/sourwine,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town/tavern)
 "aVu" = (
 /obj/effect/landmark/start/vagrant,
 /turf/open/floor/rogue/cobblerock,
@@ -1276,9 +1273,11 @@
 /obj/structure/fluff/alch,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/rtfield)
-"aXl" = (
-/obj/structure/closet/crate/roguecloset/inn/south,
-/turf/open/floor/rogue/woodturned,
+"aXv" = (
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/turf/open/floor/rogue/twig,
 /area/rogue/indoors/town/tavern)
 "aXS" = (
 /turf/open/floor/rogue/hay,
@@ -1335,10 +1334,6 @@
 /obj/structure/well/fountain,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
-"bnv" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/tavern)
 "boS" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
@@ -1416,10 +1411,6 @@
 /obj/structure/plough,
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/rtfield)
-"bzM" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
 "bAL" = (
 /obj/structure/flora/roguegrass,
 /obj/effect/decal/mossy{
@@ -1428,30 +1419,6 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
-"bBg" = (
-/obj/structure/rack/rogue/shelf/big,
-/obj/item/reagent_containers/glass/cup/steel{
-	pixel_y = 20;
-	pixel_x = 4
-	},
-/obj/item/reagent_containers/glass/cup/steel{
-	pixel_y = 20;
-	pixel_x = -4
-	},
-/obj/item/reagent_containers/glass/cup/steel{
-	pixel_y = 12;
-	pixel_x = 4
-	},
-/obj/item/reagent_containers/glass/cup/steel{
-	pixel_y = 12;
-	pixel_x = -4
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town/tavern)
-"bBB" = (
-/obj/structure/stairs,
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/tavern)
 "bBY" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -1561,6 +1528,12 @@
 /obj/item/rogueweapon/sword/long/blackflamb,
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors)
+"bOZ" = (
+/obj/structure/flora/newbranch{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town/tavern)
 "bPG" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -1583,8 +1556,8 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "bRV" = (
-/turf/open/floor/rogue/rooftop/green/corner1,
-/area/rogue/outdoors/mountains)
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town/tavern)
 "bSn" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/snow{
@@ -1644,14 +1617,6 @@
 /obj/structure/fluff/walldeco/stone,
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors)
-"ccw" = (
-/obj/structure/fluff/walldeco/innsign{
-	pixel_x = 32;
-	name = "The Dark Oak";
-	desc = "The inn of the Frozen Summit outpost. Where tales come to begin and die."
-	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
 "ccX" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors/town)
@@ -1688,6 +1653,14 @@
 	},
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/rtfield)
+"chB" = (
+/obj/structure/fluff/railing/border{
+	icon_state = "border";
+	dir = 4;
+	pixel_x = 6
+	},
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/outdoors/mountains)
 "cij" = (
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/outdoors/rtfield)
@@ -1706,6 +1679,13 @@
 "ckP" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/ruinedwood/turned,
+/area/rogue/indoors/town/tavern)
+"ckR" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/mundane/puzzlebox/easy,
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
 "clT" = (
 /turf/open/floor/rogue/twig,
@@ -1788,6 +1768,10 @@
 	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/outdoors/rtfield)
+"cwm" = (
+/obj/structure/ladder,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "cxb" = (
 /obj/effect/decal/mossy{
 	dir = 4
@@ -1824,6 +1808,14 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"cBY" = (
+/obj/structure/bed/rogue/inn/double,
+/obj/item/bedsheet/rogue/fabric_double,
+/obj/structure/fluff/walldeco/rpainting/crown{
+	pixel_x = 32
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/tavern)
 "cEg" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -1912,6 +1904,20 @@
 /obj/structure/closet/dirthole/closed/loot,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
+"cQS" = (
+/obj/structure/closet/crate/chest/neu,
+/obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
+/obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
+/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
+/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
+/obj/item/reagent_containers/food/snacks/grown/oat,
+/obj/item/reagent_containers/food/snacks/grown/oat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/onion/rogue,
+/obj/item/reagent_containers/food/snacks/grown/onion/rogue,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "cQZ" = (
 /obj/effect/landmark/start/vagrant,
 /turf/open/floor/rogue/dirt/road,
@@ -1946,20 +1952,11 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/mountains)
-"cYa" = (
-/obj/structure/fluff/railing/fence,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/tile/bath,
-/area/rogue/indoors/town/bath)
 "dba" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/far_travel,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"dcF" = (
-/obj/structure/chair/bench/coucha,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/tavern)
 "dcW" = (
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/rtfield)
@@ -1974,6 +1971,16 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"deL" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	icon_state = "border";
+	dir = 5
+	},
+/turf/open/floor/rogue/grasscold,
+/area/rogue/indoors/town/tavern)
 "dfy" = (
 /obj/structure/fluff/railing/stonehedge,
 /obj/structure/fluff/railing/stonehedge{
@@ -2059,6 +2066,10 @@
 	icon_state = "chess"
 	},
 /area/rogue/indoors/town/vault)
+"dlO" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/tavern)
 "dlX" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -2105,6 +2116,16 @@
 /obj/item/bedsheet/rogue/fabric_double,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors)
+"dxn" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/soap/herbal,
+/obj/item/soap/herbal,
+/obj/item/soap/herbal,
+/obj/item/soap/herbal,
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/town/bath)
 "dxV" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -2250,6 +2271,12 @@
 /obj/structure/bed/rogue/inn/pileofshit,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
+"dWh" = (
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/indoors/town/tavern)
 "dWZ" = (
 /obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/ruinedwood,
@@ -2346,9 +2373,6 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
-"elm" = (
-/turf/closed/wall/mineral/rogue/decowood,
-/area/rogue/indoors/town/bath)
 "ely" = (
 /obj/effect/spawner/roguemap/stump,
 /turf/open/floor/rogue/dirt,
@@ -2384,6 +2408,12 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/rtfield)
+"eop" = (
+/obj/machinery/light/rogue/wallfire{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "eor" = (
 /obj/structure/closet/crate/chest/crate,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -2428,12 +2458,6 @@
 	dir = 4
 	},
 /area/rogue/outdoors/rtfield)
-"eBe" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1
-	},
-/turf/open/floor/rogue/twig,
-/area/rogue/indoors/town/tavern)
 "eGj" = (
 /obj/structure/stairs,
 /obj/structure/fluff/railing/border{
@@ -2447,6 +2471,10 @@
 	pixel_x = -6
 	},
 /turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/tavern)
+"eHy" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/tavern)
 "eHT" = (
 /obj/structure/fluff/railing/wood{
@@ -2467,8 +2495,9 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
 "eQb" = (
-/turf/closed/wall/mineral/rogue/decowood,
-/area/rogue/indoors/town/tavern)
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/outdoors/mountains)
 "eUz" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/outdoors/rtfield)
@@ -2488,6 +2517,17 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"eWi" = (
+/obj/structure/fluff/railing/border{
+	icon_state = "border";
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	icon_state = "border";
+	dir = 9
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town/tavern)
 "eZs" = (
 /turf/open/water/swamp,
 /area/rogue/under/cave)
@@ -2501,6 +2541,10 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
+"fcY" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/tavern)
 "fdv" = (
 /obj/effect/decal/cobbleedge{
 	dir = 2
@@ -2538,11 +2582,23 @@
 /obj/structure/fluff/walldeco/painting,
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors/town/tavern)
-"fkd" = (
-/turf/closed/wall/mineral/rogue/wooddark/vertical,
-/area/rogue/indoors/town/tavern)
-"fki" = (
+"fhU" = (
+/obj/structure/flora/newbranch{
+	dir = 8
+	},
 /turf/open/transparent/openspace,
+/area/rogue/indoors/town/tavern)
+"fkd" = (
+/obj/structure/fluff/walldeco/innsign{
+	name = "The Dark Oak";
+	desc = "The inn of the Frozen Summit outpost. Where tales come to begin and die.";
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/rtfield)
+"fki" = (
+/obj/structure/mineral_door/wood/window,
+/turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/tavern)
 "flD" = (
 /obj/structure/table/wood{
@@ -2554,15 +2610,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
-"fnE" = (
-/obj/structure/closet/crate/roguecloset/inn,
-/obj/item/clothing/suit/roguetown/shirt/dress,
-/obj/item/clothing/cloak/apron/waist,
-/obj/item/clothing/shoes/roguetown/shortboots,
-/obj/item/clothing/under/roguetown/tights/stockings/white,
-/obj/item/clothing/under/roguetown/tights/stockings/silk/white,
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town/tavern)
 "fnO" = (
 /obj/structure/flora/roguetree/stump/log,
 /turf/open/floor/rogue/dirt/road,
@@ -2583,6 +2630,20 @@
 "fsP" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
+"ftj" = (
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/tavern)
+"ftz" = (
+/turf/open/floor/rogue/rooftop/green/corner1,
+/area/rogue/outdoors/mountains)
+"fuY" = (
+/obj/structure/table/wood{
+	icon_state = "longtable";
+	dir = 1
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "fvg" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/floor/rogue/dirt/road,
@@ -2616,13 +2677,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/rtfield)
-"fDf" = (
-/obj/structure/roguewindow/openclose/reinforced{
-	dir = 4
-	},
-/obj/structure/roguewindow/openclose/reinforced,
-/turf/open/floor/rogue/twig,
-/area/rogue/indoors/town/tavern)
 "fDp" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -2655,6 +2709,14 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
+"fIZ" = (
+/obj/structure/fluff/walldeco/innsign{
+	pixel_x = 32;
+	name = "The Dark Oak";
+	desc = "The inn of the Frozen Summit outpost. Where tales come to begin and die."
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/mountains)
 "fJa" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -2684,12 +2746,10 @@
 	dir = 8
 	},
 /area/rogue/outdoors/mountains)
-"fOe" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/tavern)
+"fOw" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/bath)
 "fOB" = (
 /obj/machinery/light/rogue/oven/south,
 /turf/open/floor/rogue/cobble,
@@ -2734,6 +2794,10 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"gaE" = (
+/obj/structure/closet/crate/roguecloset/inn/south,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/tavern)
 "gaQ" = (
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/carpet/royalblack,
@@ -2794,17 +2858,8 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors)
 "gkU" = (
-/obj/structure/fluff/railing/border{
-	pixel_y = -6
-	},
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 4;
-	pixel_x = 6
-	},
-/obj/structure/fluff/dryingrack,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
+/turf/closed/wall/mineral/rogue/wooddark/horizontal,
+/area/rogue/indoors/town/tavern)
 "glk" = (
 /obj/item/natural/rock,
 /turf/open/floor/rogue/dirt,
@@ -2876,6 +2931,10 @@
 /obj/structure/bed/rogue/inn/wooldouble,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/outdoors/rtfield)
+"gyV" = (
+/obj/structure/fermenting_barrel/blackgoat,
+/turf/open/floor/rogue/ruinedwood/turned,
+/area/rogue/indoors/town/tavern)
 "gzl" = (
 /obj/machinery/light/rogue/forge,
 /turf/open/floor/rogue/cobble,
@@ -2888,8 +2947,8 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town/tavern)
 "gDs" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood,
+/obj/structure/stairs,
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/tavern)
 "gEm" = (
 /obj/machinery/light/rogue/torchholder{
@@ -2897,24 +2956,9 @@
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/outdoors/rtfield)
-"gEs" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
 "gFz" = (
 /turf/open/floor/rogue/tile/bath,
-/area/rogue/indoors/town/bath)
+/area/rogue/outdoors/exposed/bath)
 "gFA" = (
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/outdoors/rtfield)
@@ -2936,12 +2980,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/rtfield)
-"gMg" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
 "gQy" = (
 /obj/machinery/light/rogue/torchholder{
 	icon_state = "torchwall1";
@@ -3002,12 +3040,6 @@
 	dir = 4
 	},
 /obj/structure/fluff/railing/wood,
-/turf/open/floor/rogue/twig,
-/area/rogue/indoors/town/tavern)
-"hbt" = (
-/obj/structure/roguewindow/openclose/reinforced{
-	dir = 1
-	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town/tavern)
 "hdL" = (
@@ -3105,14 +3137,7 @@
 "hsN" = (
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/tile/bath,
-/area/rogue/indoors/town/bath)
-"htb" = (
-/obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 4
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
+/area/rogue/outdoors/exposed/bath)
 "huD" = (
 /obj/structure/roguewindow/openclose{
 	dir = 1
@@ -3132,6 +3157,10 @@
 "hvE" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/beach)
+"hwD" = (
+/obj/structure/mineral_door/wood/deadbolt/shutter,
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/town/tavern)
 "hxJ" = (
 /obj/machinery/light/rogue/torchholder/c{
 	dir = 4
@@ -3157,10 +3186,6 @@
 	dir = 4
 	},
 /turf/open/water/bath,
-/area/rogue/indoors/town/tavern)
-"hHm" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "hHC" = (
 /turf/open/floor/rogue/wood,
@@ -3190,10 +3215,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach)
-"hMf" = (
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/grasscold,
-/area/rogue/indoors/town/tavern)
 "hOv" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -3204,14 +3225,6 @@
 /obj/item/reagent_containers/food/snacks/smallrat/dead,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
-"hPR" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 4;
-	pixel_x = 6
-	},
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
 "hRp" = (
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/hexstone,
@@ -3251,10 +3264,6 @@
 /obj/structure/roguemachine/atm,
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors/town/tavern)
-"hXx" = (
-/obj/structure/mineral_door/wood/window,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
 "hXE" = (
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/snow{
@@ -3282,10 +3291,6 @@
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave)
-"icX" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/tavern)
 "idt" = (
 /obj/structure/closet/crate/chest{
 	icon_state = "woodchestalt";
@@ -3295,14 +3300,12 @@
 /obj/item/rogueweapon/shovel,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
-"ify" = (
-/obj/structure/fluff/walldeco/innsign{
-	pixel_x = 32;
-	name = "The Dark Oak";
-	desc = "The inn of the Frozen Summit outpost. Where tales come to begin and die."
+"idG" = (
+/obj/machinery/light/rogue/wallfire{
+	pixel_y = 32
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/tavern)
 "ifS" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/flora/roguegrass,
@@ -3329,21 +3332,16 @@
 /obj/item/scomstone,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/rtfield)
-"ikx" = (
-/obj/structure/fluff/railing/border{
-	pixel_y = -6
-	},
+"iiH" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
-	dir = 8;
-	pixel_x = -6
+	dir = 8
 	},
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+/obj/structure/fluff/railing/border{
+	dir = 10
 	},
-/obj/item/clothing/mask/cigarette/pipe,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town/tavern)
 "ikB" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -3361,12 +3359,6 @@
 "inM" = (
 /turf/closed/wall/mineral/rogue/decowood/vert,
 /area/rogue/outdoors/rtfield)
-"ipT" = (
-/obj/machinery/light/rogue/wallfire{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/tavern)
 "isP" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -3382,6 +3374,10 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/mountains)
+"iuY" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/tavern)
 "iwW" = (
 /obj/machinery/light/rogue/lanternpost{
 	dir = 1
@@ -3401,6 +3397,13 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
+"iBK" = (
+/obj/structure/table/wood{
+	icon_state = "longtable";
+	dir = 4
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "iCx" = (
 /obj/structure/bed/rogue/inn/double,
 /obj/item/bedsheet/rogue/double_pelt,
@@ -3421,6 +3424,12 @@
 	desc = "A thick robe meant to be used after baths"
 	},
 /turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/tavern)
+"iDx" = (
+/obj/structure/roguewindow/openclose/reinforced{
+	dir = 1
+	},
+/turf/open/floor/rogue/twig,
 /area/rogue/indoors/town/tavern)
 "iFl" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3601,6 +3610,10 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/rtfield)
+"jgU" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/tile/bath,
+/area/rogue/outdoors/exposed/bath)
 "jgZ" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/outdoors/rtfield)
@@ -3611,10 +3624,6 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/rtfield)
-"jmJ" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/tavern)
 "jmO" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -3651,10 +3660,23 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/tavern)
 "jwt" = (
-/obj/structure/flora/newbranch{
-	dir = 1
+/obj/structure/fluff/railing/border{
+	pixel_y = -6
 	},
-/turf/open/transparent/openspace,
+/obj/structure/fluff/railing/border{
+	icon_state = "border";
+	dir = 8;
+	pixel_x = -6
+	},
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/clothing/mask/cigarette/pipe,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/outdoors/mountains)
+"jwu" = (
+/obj/structure/closet/crate/drawer/inn,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "jwv" = (
 /obj/structure/fermenting_barrel/hagwoodbitter,
@@ -3667,6 +3689,16 @@
 /obj/structure/flora/roguegrass/thorn_bush,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave)
+"jza" = (
+/obj/structure/closet/crate/chest/neu,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/food/snacks/fat,
+/obj/item/reagent_containers/food/snacks/fat,
+/obj/item/reagent_containers/food/snacks/fat,
+/obj/item/reagent_containers/food/snacks/fat,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town/tavern)
 "jzs" = (
 /obj/structure/flora/roguetree/normal{
 	icon_state = "free5"
@@ -3690,8 +3722,8 @@
 	},
 /area/rogue/outdoors/rtfield)
 "jBC" = (
-/obj/structure/fluff/wallclock/l,
-/turf/open/floor/rogue/woodturned,
+/obj/structure/fermenting_barrel/hagwoodbitter,
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
 "jBO" = (
 /obj/structure/flora/roguegrass/pyroclasticflowers,
@@ -3830,13 +3862,21 @@
 /obj/structure/spacevine,
 /turf/open/floor/rogue/dirt/ambush,
 /area/rogue/under/cave)
-"jZX" = (
-/obj/structure/mineral_door/wood/deadbolt,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
 "kal" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors)
+"kaT" = (
+/obj/structure/fluff/railing/border{
+	pixel_y = -6
+	},
+/obj/structure/fluff/railing/border{
+	icon_state = "border";
+	dir = 4;
+	pixel_x = 6
+	},
+/obj/structure/fluff/dryingrack,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/outdoors/mountains)
 "kbL" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_y = 32
@@ -3867,12 +3907,6 @@
 /obj/structure/fluff/psycross,
 /turf/open/floor/rogue/snow,
 /area/rogue/outdoors/rtfield)
-"kdM" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
 "kfp" = (
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/herringbone,
@@ -3901,11 +3935,8 @@
 /turf/open/floor/rogue/twig/platform,
 /area/rogue/indoors)
 "kjj" = (
-/obj/structure/roguewindow/openclose/reinforced{
-	dir = 4
-	},
-/turf/open/floor/rogue/twig,
-/area/rogue/indoors/town/tavern)
+/turf/open/water/bath,
+/area/rogue/outdoors/exposed/bath)
 "kjK" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf,
 /turf/open/floor/rogue/snow{
@@ -3950,6 +3981,18 @@
 /obj/item/roguegem/random,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/rtfield)
+"kul" = (
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/broom{
+	pixel_y = 10
+	},
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town/tavern)
+"kuU" = (
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grasscold,
+/area/rogue/indoors/town/tavern)
 "kuZ" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -3963,6 +4006,10 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/rtfield)
+"kyp" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/outdoors/mountains)
 "kzb" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/hexstone,
@@ -4003,6 +4050,10 @@
 /obj/structure/closet/crate/roguecloset/inn/south,
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/outdoors/rtfield)
+"kBZ" = (
+/obj/structure/ladder,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town/tavern)
 "kCr" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -4016,10 +4067,6 @@
 "kDi" = (
 /turf/open/floor/rogue/rooftop,
 /area/rogue/outdoors/mountains)
-"kEa" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/grasscold,
-/area/rogue/indoors/town/tavern)
 "kEG" = (
 /obj/structure/flora/roguegrass/bush/wall,
 /obj/structure/fluff/railing/fence{
@@ -4029,15 +4076,8 @@
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/rtfield)
 "kFF" = (
-/obj/structure/closet/crate/chest/neu_iron,
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/obj/item/reagent_containers/glass/bottle/rogue/whitewine,
-/obj/item/reagent_containers/glass/bottle/rogue/redwine,
-/obj/item/reagent_containers/glass/bottle/rogue/wine/sourwine,
-/obj/item/reagent_containers/glass/bottle/rogue/wine/sourwine,
-/obj/item/reagent_containers/glass/bottle/rogue/wine/sourwine,
-/turf/open/floor/rogue/wood/nosmooth,
+/obj/structure/flora/newtree,
+/turf/open/floor/rogue/grasscold,
 /area/rogue/indoors/town/tavern)
 "kFM" = (
 /obj/structure/table/wood{
@@ -4070,17 +4110,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/rtfield)
-"kGj" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 8
-	},
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 9
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town/tavern)
 "kHj" = (
 /obj/item/grown/log/tree/stake,
 /obj/structure/spacevine,
@@ -4122,10 +4151,6 @@
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"kLF" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/tavern)
 "kLI" = (
 /obj/structure/fluff/railing/border{
 	dir = 9;
@@ -4278,10 +4303,6 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
-"lgI" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
 "lgQ" = (
 /obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/grassred,
@@ -4297,15 +4318,9 @@
 /turf/open/floor/rogue/grasscold,
 /area/rogue/indoors/town/tavern)
 "ljR" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/soap/herbal,
-/obj/item/soap/herbal,
-/obj/item/soap/herbal,
-/obj/item/soap/herbal,
-/turf/open/floor/rogue/twig,
-/area/rogue/indoors/town/bath)
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "lkN" = (
 /obj/structure/bed/rogue/inn/double,
 /obj/item/bedsheet/rogue/double_pelt,
@@ -4314,6 +4329,11 @@
 "lnn" = (
 /turf/open/floor/rogue/snow,
 /area/rogue/outdoors/rtfield)
+"lnC" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/roguemachine/atm,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/tavern)
 "log" = (
 /turf/open/floor/rogue/snow{
 	color = "e6f2ff"
@@ -4379,16 +4399,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach)
-"lvD" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 8
-	},
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town/tavern)
 "lvL" = (
 /obj/machinery/light/rogue/torchholder/l,
 /obj/structure/fluff/railing/wood{
@@ -4405,6 +4415,11 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/rtfield)
+"lwh" = (
+/obj/structure/bed/rogue/inn/double,
+/obj/item/bedsheet/rogue/double_pelt,
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/indoors/town/tavern)
 "lws" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/mudcrab{
 	dir = 8
@@ -4445,6 +4460,10 @@
 	},
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/rtfield)
+"lAJ" = (
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/tavern)
 "lAU" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8;
@@ -4488,18 +4507,6 @@
 /obj/structure/stairs,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
-"lLu" = (
-/obj/structure/fluff/railing/border{
-	pixel_y = -6
-	},
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
-"lLT" = (
-/obj/structure/closet/crate/chest/neu,
-/obj/item/book/rogue/cooking,
-/obj/item/reagent_containers/glass/bottle/waterskin/milk,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town/tavern)
 "lNx" = (
 /obj/machinery/light/rogue/torchholder{
 	icon_state = "torchwall1";
@@ -4554,10 +4561,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave)
-"lXD" = (
-/obj/structure/ladder,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town/tavern)
 "maz" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -4574,8 +4577,8 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
 "maY" = (
-/obj/structure/roguewindow,
-/turf/open/floor/rogue/twig,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "mcz" = (
 /obj/machinery/light/rogue/torchholder/l,
@@ -4611,10 +4614,7 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
 "mke" = (
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = 24
-	},
-/turf/open/transparent/openspace,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town/tavern)
 "mlT" = (
 /obj/structure/fluff/railing/wood{
@@ -4623,22 +4623,16 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
-"mmQ" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/roguemachine/atm,
-/turf/open/floor/rogue/herringbone,
+"mmm" = (
+/obj/structure/flora/newbranch{
+	dir = 1
+	},
+/turf/open/transparent/openspace,
 /area/rogue/indoors/town/tavern)
 "moC" = (
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"mrD" = (
-/obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
 "mrM" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -4717,6 +4711,12 @@
 /obj/structure/fluff/dryingrack,
 /turf/open/floor/rogue/twig/platform,
 /area/rogue/indoors)
+"mCZ" = (
+/obj/structure/fluff/railing/border{
+	pixel_y = -6
+	},
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/outdoors/mountains)
 "mDa" = (
 /obj/structure/spacevine,
 /turf/open/transparent/openspace,
@@ -4754,6 +4754,13 @@
 /obj/structure/bed/rogue,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors)
+"mFL" = (
+/obj/structure/fluff/railing/border{
+	icon_state = "border";
+	dir = 8
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town/tavern)
 "mIn" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/naturalstone,
@@ -4774,14 +4781,6 @@
 	},
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors)
-"mLy" = (
-/obj/structure/bed/rogue/inn/double,
-/obj/item/bedsheet/rogue/fabric_double,
-/obj/structure/fluff/walldeco/rpainting/crown{
-	pixel_x = 32
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/tavern)
 "mLS" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/naturalstone,
@@ -4847,10 +4846,6 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
-"mWn" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/tavern)
 "mXc" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/transparent/openspace,
@@ -4861,6 +4856,21 @@
 	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/outdoors/rtfield)
+"mZU" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/outdoors/mountains)
 "neh" = (
 /obj/machinery/light/rogue/campfire,
 /turf/open/floor/rogue/dirt/road,
@@ -4937,6 +4947,15 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
+"nsN" = (
+/obj/structure/fluff/railing/border{
+	icon_state = "border";
+	dir = 8;
+	pixel_x = -6
+	},
+/obj/structure/chair/wood/rogue/chair3,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/outdoors/mountains)
 "ntv" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors/town/vault)
@@ -4990,9 +5009,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"nEJ" = (
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
 "nFv" = (
 /obj/machinery/light/rogue/smelter,
 /turf/open/floor/rogue/hexstone,
@@ -5028,6 +5044,10 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/rtfield)
+"nOh" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/tile/bath,
+/area/rogue/outdoors/exposed/bath)
 "nPK" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt/road,
@@ -5057,6 +5077,10 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
+"oaM" = (
+/obj/structure/fermenting_barrel,
+/turf/open/floor/rogue/ruinedwood/turned,
+/area/rogue/indoors/town/tavern)
 "obx" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors)
@@ -5072,8 +5096,12 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
 "odW" = (
-/obj/structure/roguewindow/openclose/reinforced,
-/turf/open/floor/rogue/twig,
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	pixel_y = 6
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/tavern)
 "ogi" = (
 /turf/open/water/ocean{
@@ -5081,14 +5109,6 @@
 	water_reagent = /datum/reagent/water
 	},
 /area/rogue/outdoors/beach)
-"ogv" = (
-/obj/structure/fluff/railing/border{
-	dir = 1;
-	pixel_y = 6
-	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/tavern)
 "oic" = (
 /obj/structure/roguemachine/atm,
 /turf/open/floor/rogue/hexstone,
@@ -5153,7 +5173,7 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors)
 "osM" = (
-/turf/closed/wall/mineral/rogue/wooddark/horizontal,
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
 "otl" = (
 /obj/machinery/light/rogue/wallfire{
@@ -5161,16 +5181,21 @@
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
+"otC" = (
+/obj/structure/closet/crate/roguecloset/inn,
+/obj/item/clothing/suit/roguetown/shirt/dress,
+/obj/item/clothing/cloak/apron/waist,
+/obj/item/clothing/shoes/roguetown/shortboots,
+/obj/item/clothing/under/roguetown/tights/stockings/white,
+/obj/item/clothing/under/roguetown/tights/stockings/silk/white,
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/indoors/town/tavern)
 "ouw" = (
 /turf/open/water/river{
 	icon_state = "rockwd";
 	dir = 4
 	},
 /area/rogue/outdoors/mountains)
-"ouD" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/tile/bath,
-/area/rogue/indoors/town/bath)
 "oyy" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/table/wood{
@@ -5208,25 +5233,6 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"oCR" = (
-/obj/structure/rack/rogue/shelf/big,
-/obj/item/kitchen/spoon,
-/obj/item/kitchen/spoon,
-/obj/item/kitchen/spoon,
-/obj/item/kitchen/spoon,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/cooking/platter,
-/obj/item/cooking/platter,
-/obj/item/cooking/platter,
-/obj/item/kitchen/fork,
-/obj/item/kitchen/fork,
-/obj/item/kitchen/fork,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
 "oDG" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 1
@@ -5286,6 +5292,11 @@
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/rtfield)
+"oNl" = (
+/obj/structure/fluff/railing/fence,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/tile/bath,
+/area/rogue/outdoors/exposed/bath)
 "oNT" = (
 /obj/structure/stairs{
 	icon_state = "stairs";
@@ -5293,6 +5304,12 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
+"oOL" = (
+/obj/structure/flora/newbranch/connector{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town/tavern)
 "oPb" = (
 /obj/machinery/light/rogue/smelter/great,
 /turf/open/floor/rogue/cobble,
@@ -5329,6 +5346,11 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/outdoors/rtfield)
+"oVz" = (
+/obj/structure/fluff/railing/fence,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/tile/bath,
+/area/rogue/outdoors/exposed/bath)
 "oVD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/chair/stool/bar/rogue,
@@ -5383,8 +5405,16 @@
 	color = "e6f2ff"
 	},
 /area/rogue/outdoors/rtfield)
+"pcH" = (
+/obj/structure/mineral_door/wood/deadbolt,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "pcR" = (
-/turf/open/floor/rogue/wood/herringbone,
+/obj/structure/stairs{
+	icon_state = "stairs";
+	dir = 4
+	},
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "pdz" = (
 /obj/structure/mineral_door/wood/deadbolt{
@@ -5598,10 +5628,6 @@
 	},
 /turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/tavern)
-"pFA" = (
-/obj/structure/chair/bench/coucha/r,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/tavern)
 "pFB" = (
 /obj/structure/fluff/railing/border,
 /obj/machinery/light/rogue/wallfire/candle{
@@ -5623,9 +5649,6 @@
 	color = "e6f2ff"
 	},
 /area/rogue/outdoors/rtfield)
-"pHZ" = (
-/turf/open/floor/rogue/rooftop/green,
-/area/rogue/outdoors/mountains)
 "pIl" = (
 /obj/structure/globe,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -5651,20 +5674,6 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
-"pJx" = (
-/obj/structure/closet/crate/chest/neu,
-/obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
-/obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
-/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
-/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
-/obj/item/reagent_containers/food/snacks/grown/oat,
-/obj/item/reagent_containers/food/snacks/grown/oat,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/onion/rogue,
-/obj/item/reagent_containers/food/snacks/grown/onion/rogue,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
 "pKQ" = (
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors)
@@ -5747,24 +5756,23 @@
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/snow,
 /area/rogue/outdoors/rtfield)
+"qeh" = (
+/obj/structure/closet/crate/drawer/inn,
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/indoors/town/tavern)
 "qfF" = (
 /obj/structure/flora/rogueshroom,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
-"qgI" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/tavern)
 "qhe" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
-"qjb" = (
-/obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 8
+"qje" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/outdoors/mountains)
 "qjj" = (
 /obj/item/gun/ballistic/arquebus_pistol,
 /obj/effect/decal/remains/human,
@@ -5803,6 +5811,9 @@
 /obj/item/rogueweapon/spear/stone,
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/rtfield)
+"qoP" = (
+/turf/closed/wall/mineral/rogue/decowood,
+/area/rogue/indoors/town/bath)
 "qpJ" = (
 /obj/structure/fluff/railing/wood{
 	pixel_x = 1;
@@ -5810,6 +5821,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/mountains)
+"qqk" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "qqZ" = (
 /obj/structure/table/wood{
 	icon_state = "longtable";
@@ -5823,19 +5840,20 @@
 /turf/closed/mineral/random/rogue/high,
 /area/rogue/indoors/town/tavern)
 "qsC" = (
-/obj/structure/flora/newbranch{
-	dir = 4
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/town/tavern)
-"qtZ" = (
-/obj/structure/rack/rogue/shelf/big,
-/obj/item/broom{
-	pixel_y = 10
+/obj/structure/fluff/railing/border{
+	icon_state = "border";
+	dir = 9
 	},
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town/tavern)
+/obj/structure/fluff/railing/border{
+	icon_state = "border";
+	dir = 8;
+	pixel_x = -6
+	},
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/outdoors/mountains)
 "quh" = (
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/dirt/road,
@@ -5944,10 +5962,6 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/cow,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
-"qUa" = (
-/obj/structure/mineral_door/wood/window,
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/tavern)
 "qUh" = (
 /obj/structure/fluff/railing/wood{
 	pixel_x = 1;
@@ -5984,6 +5998,9 @@
 /obj/machinery/light/rogue/campfire/densefire,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
+"qWx" = (
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/bath)
 "qYz" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/outdoors/rtfield)
@@ -6026,11 +6043,6 @@
 	},
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/rtfield)
-"rbr" = (
-/obj/structure/fluff/railing/fence,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/tile/bath,
-/area/rogue/indoors/town/bath)
 "rbt" = (
 /obj/structure/bed/rogue/inn/hay,
 /obj/effect/landmark/start/manorguardsman,
@@ -6085,26 +6097,58 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
+"rqo" = (
+/obj/structure/closet/crate/chest/neu,
+/obj/item/book/rogue/cooking,
+/obj/item/reagent_containers/glass/bottle/waterskin/milk,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town/tavern)
+"rqW" = (
+/obj/structure/stairs,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/tavern)
 "rrv" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
+"rsd" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/indoors/town/tavern)
 "rwQ" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/snow{
 	color = "e6f2ff"
 	},
 /area/rogue/indoors/town)
-"ryO" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/bath)
 "rAw" = (
 /obj/structure/flora/roguetree/snow,
 /turf/open/floor/rogue/snow{
 	color = "e6f2ff"
 	},
 /area/rogue/outdoors/rtfield)
+"rCR" = (
+/turf/open/floor/rogue/rooftop/green,
+/area/rogue/outdoors/mountains)
+"rCX" = (
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/kitchen/spoon,
+/obj/item/kitchen/spoon,
+/obj/item/kitchen/spoon,
+/obj/item/kitchen/spoon,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/kitchen/fork,
+/obj/item/kitchen/fork,
+/obj/item/kitchen/fork,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "rCZ" = (
 /obj/structure/stairs{
 	icon_state = "stairs";
@@ -6157,8 +6201,12 @@
 /obj/item/clothing/under/roguetown/tights/stockings,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/tavern)
-"rJa" = (
+"rIA" = (
+/obj/structure/fluff/wallclock/l,
 /turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/tavern)
+"rJa" = (
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/tavern)
 "rJC" = (
 /turf/open/floor/rogue/wood,
@@ -6289,6 +6337,17 @@
 	},
 /turf/open/floor/rogue/snow,
 /area/rogue/outdoors/rtfield)
+"san" = (
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	pixel_y = 6
+	},
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/toy/cards/deck,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/tavern)
 "sbR" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave)
@@ -6311,19 +6370,15 @@
 	color = "e6f2ff"
 	},
 /area/rogue/outdoors/rtfield)
-"sct" = (
-/obj/structure/flora/newtree,
-/turf/open/floor/rogue/grasscold,
+"scS" = (
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = 24
+	},
+/turf/open/transparent/openspace,
 /area/rogue/indoors/town/tavern)
 "sdw" = (
 /turf/open/floor/rogue/churchrough,
 /area/rogue/outdoors/rtfield)
-"shJ" = (
-/obj/structure/flora/newbranch{
-	dir = 8
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/town/tavern)
 "shW" = (
 /obj/structure/fermenting_barrel/zagul,
 /obj/structure/fluff/railing/border{
@@ -6372,8 +6427,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "skH" = (
-/obj/structure/closet/crate/drawer/inn,
-/turf/open/floor/rogue/wood,
+/turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/tavern)
 "slK" = (
 /obj/structure/mineral_door/wood/fancywood{
@@ -6458,27 +6512,16 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
+"svu" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/tavern)
 "sxT" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
-"sAL" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 9
-	},
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 8;
-	pixel_x = -6
-	},
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
 "sCB" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
@@ -6509,6 +6552,26 @@
 /obj/structure/table/wood,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/rtfield)
+"sHT" = (
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/reagent_containers/glass/cup/steel{
+	pixel_y = 20;
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/glass/cup/steel{
+	pixel_y = 20;
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/glass/cup/steel{
+	pixel_y = 12;
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/glass/cup/steel{
+	pixel_y = 12;
+	pixel_x = -4
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town/tavern)
 "sJC" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -6541,12 +6604,6 @@
 	dir = 4
 	},
 /area/rogue/outdoors/rtfield)
-"sLw" = (
-/obj/structure/mineral_door/wood/deadbolt{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town/tavern)
 "sNs" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -6584,11 +6641,6 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/rtfield)
-"sWA" = (
-/obj/structure/bed/rogue/inn/double,
-/obj/item/bedsheet/rogue/double_pelt,
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town/tavern)
 "sXd" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -6685,16 +6737,9 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
-"thV" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/tile/bath,
-/area/rogue/indoors/town/bath)
 "tjx" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 8
-	},
-/turf/open/floor/rogue/wood/nosmooth,
+/obj/structure/roguewindow,
+/turf/open/floor/rogue/twig,
 /area/rogue/indoors/town/tavern)
 "tjy" = (
 /obj/structure/flora/newtree,
@@ -6718,13 +6763,15 @@
 /obj/structure/fluff/walldeco/customflag,
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors/town/tavern)
-"tmg" = (
-/obj/structure/chair/wood/rogue,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
 "tmD" = (
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/tavern)
+"tmT" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/tavern)
 "tnz" = (
 /obj/structure/fluff/railing/wood,
@@ -6806,6 +6853,14 @@
 /obj/structure/rack/rogue/shelf/biggest,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
+"tIG" = (
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	pixel_y = 6
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/tavern)
 "tKp" = (
 /turf/open/floor/carpet/royalblack,
 /area/rogue/outdoors/rtfield)
@@ -6859,10 +6914,6 @@
 	},
 /turf/open/floor/rogue/grasscold,
 /area/rogue/indoors/town/tavern)
-"tTY" = (
-/obj/structure/closet/crate/drawer/inn,
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town/tavern)
 "tVm" = (
 /obj/structure/closet/crate/chest/old_crate,
 /obj/item/rogueweapon/hammer,
@@ -6884,15 +6935,22 @@
 "tXZ" = (
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
-"tZu" = (
-/obj/machinery/light/rogue/wallfire{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
 "ubC" = (
 /turf/open/water/swamp,
 /area/rogue/outdoors/rtfield)
+"udt" = (
+/obj/structure/closet/crate/chest/neu,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/fat,
+/obj/item/reagent_containers/food/snacks/fat,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "ueS" = (
 /mob/living/carbon/human/species/goblin/npc/cave,
 /turf/open/floor/rogue/dirt/road,
@@ -6902,15 +6960,6 @@
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/rtfield)
-"uhv" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 1
-	},
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
 "ujo" = (
 /turf/open/floor/rogue/rooftop{
 	dir = 4
@@ -6940,18 +6989,14 @@
 	},
 /turf/open/floor/rogue/snow,
 /area/rogue/outdoors/rtfield)
+"ulA" = (
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/grasscold,
+/area/rogue/indoors/town/tavern)
 "umP" = (
 /obj/item/natural/rock,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
-"umU" = (
-/obj/structure/mineral_door/wood/window,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/tavern)
-"unA" = (
-/obj/structure/ladder,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
 "unS" = (
 /obj/structure/table/wood,
 /obj/structure/mirror{
@@ -6976,8 +7021,9 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield)
 "uro" = (
-/turf/open/water/bath,
-/area/rogue/indoors/town/bath)
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/tavern)
 "urD" = (
 /obj/structure/mineral_door/wood{
 	name = "house ii";
@@ -7053,14 +7099,6 @@
 	icon_state = "rockwd";
 	dir = 1
 	},
-/area/rogue/outdoors/rtfield)
-"uGV" = (
-/obj/structure/fluff/walldeco/innsign{
-	name = "The Dark Oak";
-	desc = "The inn of the Frozen Summit outpost. Where tales come to begin and die.";
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
 "uIM" = (
 /obj/structure/table/wood{
@@ -7169,9 +7207,9 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
-"vhe" = (
-/obj/structure/stairs,
-/turf/open/floor/rogue/herringbone,
+"vhT" = (
+/obj/structure/chair/bench/coucha,
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
 "vir" = (
 /obj/machinery/light/rogue/smelter/great,
@@ -7261,8 +7299,8 @@
 /turf/open/floor/rogue/dirt/ambush,
 /area/rogue/outdoors/mountains)
 "vuK" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/herringbone,
+/obj/structure/mineral_door/wood/window,
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/tavern)
 "vwR" = (
 /obj/machinery/light/rogue/torchholder{
@@ -7290,6 +7328,10 @@
 /obj/item/natural/rock,
 /turf/open/water/swamp,
 /area/rogue/under/cave)
+"vBa" = (
+/obj/structure/chair/bench/coucha/r,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/tavern)
 "vDe" = (
 /obj/structure/spacevine,
 /turf/open/floor/rogue/dirt,
@@ -7303,6 +7345,10 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
+"vEo" = (
+/obj/structure/chair/wood/rogue,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "vFx" = (
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town/bath)
@@ -7337,10 +7383,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/rtfield)
-"vJD" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town/tavern)
 "vJT" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/hoe,
@@ -7430,7 +7472,7 @@
 "vVR" = (
 /obj/structure/fluff/walldeco/maidensigil,
 /turf/open/floor/rogue/tile/bath,
-/area/rogue/indoors/town/bath)
+/area/rogue/outdoors/exposed/bath)
 "vWh" = (
 /obj/structure/boatbell/fluff{
 	desc = ""
@@ -7483,10 +7525,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/rtfield)
-"wbR" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/tavern)
 "wbS" = (
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/dirt/road,
@@ -7597,10 +7635,26 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors)
+"woj" = (
+/obj/structure/table/wood{
+	icon_state = "longtable";
+	dir = 8
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "wpd" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach)
+"wqt" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/outdoors/mountains)
 "wqE" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -7677,6 +7731,10 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/rtfield)
+"wIl" = (
+/obj/structure/mineral_door/wood/window,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "wJw" = (
 /obj/machinery/light/rogue/torchholder{
 	icon_state = "torchwall1";
@@ -7718,6 +7776,9 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"wQq" = (
+/turf/closed/wall/mineral/rogue/wooddark/vertical,
+/area/rogue/indoors/town/tavern)
 "wQC" = (
 /obj/machinery/light/rogue/torchholder{
 	icon_state = "torchwall1";
@@ -7779,13 +7840,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
-"wYH" = (
-/obj/structure/stairs{
-	icon_state = "stairs";
-	dir = 4
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
 "wZe" = (
 /obj/effect/landmark/start/veteran,
 /turf/open/floor/rogue/dirt/road,
@@ -7822,17 +7876,6 @@
 	dir = 1
 	},
 /area/rogue/outdoors/rtfield)
-"xdS" = (
-/obj/structure/fluff/railing/border{
-	dir = 1;
-	pixel_y = 6
-	},
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/toy/cards/deck,
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/tavern)
 "xeq" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/snow,
@@ -7931,14 +7974,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave)
-"xnN" = (
-/obj/structure/fluff/railing/border{
-	dir = 1;
-	pixel_y = 6
-	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/tavern)
 "xoz" = (
 /obj/structure/roguemachine/steward,
 /obj/structure/table/wood,
@@ -7984,13 +8019,6 @@
 /obj/structure/well,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/rtfield)
-"xyE" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/mundane/puzzlebox/easy,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/tavern)
 "xzP" = (
 /obj/structure/fluff/railing/wood,
 /obj/structure/fluff/railing/wood{
@@ -8006,10 +8034,6 @@
 /area/rogue/outdoors/rtfield)
 "xAZ" = (
 /turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/tavern)
-"xBg" = (
-/obj/structure/fermenting_barrel/hagwoodbitter,
-/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
 "xBE" = (
 /obj/structure/fluff/railing/wood,
@@ -8047,19 +8071,6 @@
 	color = "e6f2ff"
 	},
 /area/rogue/outdoors/rtfield)
-"xEW" = (
-/obj/structure/closet/crate/chest/neu,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/reagent_containers/food/snacks/fat,
-/obj/item/reagent_containers/food/snacks/fat,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
 "xHh" = (
 /obj/machinery/light/rogue/torchholder{
 	icon_state = "torchwall1";
@@ -8075,12 +8086,8 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave)
 "xIP" = (
-/turf/closed/wall/mineral/rogue/wooddark,
-/area/rogue/indoors/town/tavern)
-"xJZ" = (
-/obj/structure/fermenting_barrel,
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors/town/tavern)
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/outdoors/mountains)
 "xLL" = (
 /obj/structure/stairs{
 	icon_state = "stairs";
@@ -8132,20 +8139,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
-"xSc" = (
-/obj/structure/closet/crate/chest/neu,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/food/snacks/fat,
-/obj/item/reagent_containers/food/snacks/fat,
-/obj/item/reagent_containers/food/snacks/fat,
-/obj/item/reagent_containers/food/snacks/fat,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town/tavern)
-"xUT" = (
-/obj/structure/fermenting_barrel/blackgoat,
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors/town/tavern)
 "xWm" = (
 /obj/machinery/light/rogue/cauldron,
 /turf/open/floor/rogue/blocks,
@@ -8206,8 +8199,7 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/rtfield)
 "ygR" = (
-/obj/structure/mineral_door/wood/deadbolt/shutter,
-/turf/open/floor/rogue/twig,
+/turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors/town/tavern)
 "ygT" = (
 /obj/effect/decal/cleanable/blood,
@@ -8217,15 +8209,6 @@
 /obj/structure/flora/roguegrass/swampweed,
 /turf/open/floor/rogue/dirt/ambush,
 /area/rogue/under/cave)
-"yiK" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 8;
-	pixel_x = -6
-	},
-/obj/structure/chair/wood/rogue/chair3,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
 "yjc" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/mountains)
@@ -43808,7 +43791,7 @@ fLa
 quh
 fsP
 fsP
-ccw
+aCU
 fsP
 fsP
 fsP
@@ -43964,16 +43947,16 @@ iSL
 rYw
 haj
 haj
-maY
-eQb
+tjx
+ygR
 pLn
 pLn
-eQb
-maY
-eQb
-eQb
-eQb
-eQb
+ygR
+tjx
+ygR
+ygR
+ygR
+ygR
 haj
 haj
 abe
@@ -44120,9 +44103,9 @@ abV
 iSL
 rYw
 haj
-hMf
+kuU
 cOL
-kEa
+ulA
 vqm
 vqm
 acj
@@ -44276,20 +44259,20 @@ hHC
 abV
 iSL
 aaf
-maY
+tjx
 cOL
 lhz
 ifS
 vqm
 vqm
 acj
-mrD
+fuY
 jRN
 jRN
 jRN
 jRN
-wYH
-eQb
+pcR
+ygR
 mVe
 fsP
 fsP
@@ -44433,21 +44416,21 @@ hHC
 cty
 iSL
 iSL
-maY
+tjx
 feq
-sct
+kFF
 pFB
 vqm
 vqm
 vqm
-eQb
-htb
+ygR
+iBK
 uIM
 uIM
-qjb
-eQb
-eQb
-uGV
+woj
+ygR
+ygR
+fkd
 fsP
 fsP
 mVe
@@ -44590,20 +44573,20 @@ hHC
 cty
 iSL
 iSL
-maY
-aHs
+tjx
+deL
 aEv
 tTH
 vqm
 vqm
 vqm
-qgI
+svu
 acj
 acj
 acj
 acj
-qgI
-eQb
+svu
+ygR
 mVe
 fsP
 fsP
@@ -44747,14 +44730,14 @@ abV
 abV
 iSL
 iSL
-eQb
+ygR
 vqm
 vqm
 vqm
 vqm
 vqm
 vqm
-kLF
+ftj
 vqm
 vqm
 vqm
@@ -44904,13 +44887,13 @@ rDz
 abV
 iSL
 iSL
-eQb
-vuK
-vhe
-eQb
-mmQ
+ygR
+iuY
+rqW
+ygR
+lnC
 vqm
-icX
+eHy
 haj
 haj
 haj
@@ -45063,17 +45046,17 @@ vJn
 iSL
 haj
 vqm
-vhe
-eQb
-elm
+rqW
+ygR
+qoP
 cgj
-elm
+qoP
 aqr
-ouD
-uro
-uro
-uro
-rbr
+jgU
+kjj
+kjj
+kjj
+oNl
 fRr
 mVe
 fsP
@@ -45223,13 +45206,13 @@ haj
 haj
 aqr
 uqL
-aCU
+qWx
 vFx
 aqr
 vVR
-uro
-uro
-uro
+kjj
+kjj
+kjj
 hsN
 mVe
 fsP
@@ -45380,13 +45363,13 @@ xqr
 xqr
 aqr
 tOE
-aCU
+qWx
 vFx
 sux
 gFz
-uro
-uro
-uro
+kjj
+kjj
+kjj
 hsN
 mVe
 fsP
@@ -45535,15 +45518,15 @@ xqr
 xqr
 xqr
 lnn
-elm
+qoP
 tOE
-aCU
+qWx
 vFx
 sux
 gFz
-uro
-uro
-uro
+kjj
+kjj
+kjj
 hsN
 fRr
 fsP
@@ -45694,13 +45677,13 @@ xqr
 lnn
 aqr
 tOE
-ryO
-ljR
+fOw
+dxn
 aqr
 vVR
-uro
-uro
-uro
+kjj
+kjj
+kjj
 hsN
 fRr
 mVe
@@ -45851,14 +45834,14 @@ lnn
 lnn
 aqr
 aqr
-elm
+qoP
 aqr
 aqr
-thV
+nOh
 gFz
 gFz
 gFz
-cYa
+oVz
 mVe
 fsP
 fsP
@@ -68148,7 +68131,7 @@ sPC
 sPC
 sPC
 sPC
-ify
+fIZ
 sPC
 sPC
 sPC
@@ -68300,16 +68283,16 @@ tXZ
 tXZ
 haj
 haj
-kjj
-eQb
-eQb
-kjj
-qUa
-eQb
-eQb
-eQb
-eQb
-eQb
+tjx
+ygR
+ygR
+tjx
+vuK
+ygR
+ygR
+ygR
+ygR
+ygR
 haj
 haj
 tXZ
@@ -68456,18 +68439,18 @@ kDi
 tXZ
 tXZ
 haj
-fki
-shJ
-fki
-xnN
-pcR
-pcR
-wbR
-eQb
+bRV
+fhU
+bRV
+odW
+rJa
+rJa
+uro
+ygR
 xfP
 jvD
 xbj
-fki
+bRV
 haj
 tXZ
 tXZ
@@ -68612,20 +68595,20 @@ kDi
 kDi
 tXZ
 tXZ
-eQb
-fki
-aQU
-fki
-ogv
-mWn
-pcR
-pcR
 ygR
+bRV
+oOL
+bRV
+tIG
+lAJ
+rJa
+rJa
+hwD
 jRN
 jRN
 oyy
-fki
-eQb
+bRV
+ygR
 tXZ
 tXZ
 tXZ
@@ -68769,20 +68752,20 @@ kDi
 kDi
 tXZ
 tXZ
-odW
-jwt
+tjx
+mmm
 tjy
-mke
-xdS
-fOe
-pcR
-pcR
-eQb
-oCR
+scS
+san
+tmT
+rJa
+rJa
+ygR
+rCX
 jRN
 jRN
-wYH
-hbt
+pcR
+iDx
 tXZ
 tXZ
 tXZ
@@ -68926,20 +68909,20 @@ kDi
 kDi
 tXZ
 tXZ
-fDf
-fki
-qsC
-fki
-ogv
-mWn
-pcR
-pcR
-eQb
+tjx
+bRV
+bOZ
+bRV
+tIG
+lAJ
+rJa
+rJa
+ygR
 ssA
 jRN
 jRN
-unA
-eQb
+cwm
+ygR
 tXZ
 tXZ
 tXZ
@@ -69083,19 +69066,19 @@ kDi
 kDi
 tXZ
 tXZ
-odW
-fki
-fki
-fki
+tjx
+bRV
+bRV
+bRV
 pDl
-pcR
-pcR
-pcR
-hXx
+rJa
+rJa
+rJa
+wIl
 xki
-gDs
-pJx
-xEW
+maY
+cQS
+udt
 haj
 tXZ
 tXZ
@@ -69240,18 +69223,18 @@ kDi
 kDi
 tXZ
 tXZ
-eQb
-fki
-fki
+ygR
+bRV
+bRV
 eGj
-pcR
-pcR
-pcR
-pcR
-eQb
-eQb
-eQb
-eQb
+rJa
+rJa
+rJa
+rJa
+ygR
+ygR
+ygR
+ygR
 haj
 haj
 tXZ
@@ -69398,19 +69381,19 @@ kDi
 tXZ
 tXZ
 haj
-fki
-fki
-bBB
-bnv
-pcR
-pcR
-pcR
-jZX
+bRV
+bRV
+gDs
+dlO
+rJa
+rJa
+rJa
+pcH
 jRN
-hHm
+ljR
 jRN
-eBe
-pHZ
+aXv
+rCR
 tXZ
 tXZ
 tXZ
@@ -69556,18 +69539,18 @@ tXZ
 tXZ
 haj
 haj
-eQb
-eQb
-eQb
-eQb
-pcR
-pcR
-eQb
-skH
+ygR
+ygR
+ygR
+ygR
+rJa
+rJa
+ygR
+jwu
 iXp
-kdM
-eQb
-pHZ
+qqk
+ygR
+rCR
 tXZ
 tXZ
 tXZ
@@ -69710,21 +69693,21 @@ kDi
 kDi
 kDi
 tXZ
-sAL
-bzM
-umU
-rJa
-jBC
-rJa
+qsC
+kyp
+fki
+osM
+rIA
+osM
 pdz
-pcR
-pcR
-eQb
-eQb
-eQb
-eQb
-eQb
-pHZ
+rJa
+rJa
+ygR
+ygR
+ygR
+ygR
+ygR
+rCR
 tXZ
 tXZ
 tXZ
@@ -69867,21 +69850,21 @@ tXZ
 tXZ
 tXZ
 tXZ
-gMg
-nEJ
-eQb
-dcF
-xyE
+qje
+xIP
+ygR
+vhT
+ckR
+osM
+ygR
+fcY
 rJa
-eQb
-jmJ
-pcR
-jZX
+pcH
 jRN
-tmg
-kdM
-eBe
-pHZ
+vEo
+qqk
+aXv
+rCR
 tXZ
 tXZ
 tXZ
@@ -70024,21 +70007,21 @@ tXZ
 tXZ
 tXZ
 tXZ
-gEs
-uhv
-eQb
-pFA
+mZU
+wqt
+ygR
+vBa
+osM
+osM
+ygR
 rJa
 rJa
-eQb
-pcR
-pcR
-eQb
-tZu
+ygR
+eop
 jRN
 jRN
-eQb
-pHZ
+ygR
+rCR
 tXZ
 tXZ
 tXZ
@@ -70183,19 +70166,19 @@ tXZ
 tXZ
 tXZ
 tXZ
-eQb
-ipT
+ygR
+idG
+osM
+osM
+ygR
 rJa
 rJa
-eQb
-pcR
-pcR
-eQb
+ygR
 pof
 iCx
 jRN
 haj
-pHZ
+rCR
 tXZ
 tXZ
 tXZ
@@ -70340,19 +70323,19 @@ tXZ
 tXZ
 tXZ
 tXZ
-eQb
-aXl
-mLy
-rJa
-eQb
-eQb
-eQb
-eQb
-eQb
-eQb
+ygR
+gaE
+cBY
+osM
+ygR
+ygR
+ygR
+ygR
+ygR
+ygR
 haj
 haj
-bRV
+ftz
 tXZ
 tXZ
 tXZ
@@ -70497,11 +70480,11 @@ tXZ
 tXZ
 tXZ
 tXZ
-eQb
-eQb
-eQb
-eQb
-eQb
+ygR
+ygR
+ygR
+ygR
+ygR
 tXZ
 tXZ
 tXZ
@@ -92486,11 +92469,11 @@ kDi
 kDi
 kDi
 kDi
-xIP
-osM
-xIP
-osM
-xIP
+skH
+gkU
+skH
+gkU
+skH
 tXZ
 tXZ
 tXZ
@@ -92643,11 +92626,11 @@ kDi
 kDi
 kDi
 kDi
-xIP
-xUT
-xBg
-xJZ
-xIP
+skH
+gyV
+jBC
+oaM
+skH
 tXZ
 tXZ
 tXZ
@@ -92800,11 +92783,11 @@ kDi
 kDi
 kDi
 kDi
-xIP
-kGj
-tjx
-lvD
-xIP
+skH
+eWi
+mFL
+iiH
+skH
 tXZ
 tXZ
 tXZ
@@ -92957,11 +92940,11 @@ kDi
 kDi
 kDi
 kDi
-fkd
-qtZ
-aov
-xSc
-fkd
+wQq
+kul
+mke
+jza
+wQq
 tXZ
 tXZ
 tXZ
@@ -93114,11 +93097,11 @@ kDi
 kDi
 kDi
 kDi
-xIP
-bBg
-aov
-lLT
-xIP
+skH
+sHT
+mke
+rqo
+skH
 tXZ
 tXZ
 tXZ
@@ -93271,11 +93254,11 @@ kDi
 kDi
 kDi
 kDi
-xIP
-kFF
-aov
-lXD
-xIP
+skH
+aVf
+mke
+kBZ
+skH
 tXZ
 tXZ
 tXZ
@@ -93428,13 +93411,13 @@ kDi
 kDi
 kDi
 kDi
-xIP
-osM
-sLw
-osM
-xIP
-yiK
-ikx
+skH
+gkU
+dWh
+gkU
+skH
+nsN
+jwt
 tXZ
 tXZ
 tXZ
@@ -93584,14 +93567,14 @@ kDi
 kDi
 kDi
 kDi
-xIP
-xIP
-vJD
+skH
+skH
+rsd
 smO
 smO
+skH
 xIP
-nEJ
-lLu
+mCZ
 tXZ
 tXZ
 tXZ
@@ -93741,14 +93724,14 @@ kDi
 kDi
 kDi
 kDi
-fkd
-fnE
+wQq
+otC
 smO
 smO
 smO
-fkd
-lgI
-lLu
+wQq
+eQb
+mCZ
 tXZ
 tXZ
 tXZ
@@ -93898,14 +93881,14 @@ kDi
 kDi
 kDi
 kDi
-xIP
-xIP
-tTY
-sWA
+skH
+skH
+qeh
+lwh
 smO
-umU
-hPR
-gkU
+fki
+chB
+kaT
 tXZ
 tXZ
 tXZ
@@ -94056,11 +94039,11 @@ kDi
 kDi
 kDi
 kDi
-xIP
-osM
-xIP
-osM
-xIP
+skH
+gkU
+skH
+gkU
+skH
 tXZ
 tXZ
 tXZ

--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -1047,10 +1047,6 @@
 /obj/structure/fluff/dryingrack,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/rtfield)
-"agk" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/bath)
 "ahG" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
@@ -1081,6 +1077,9 @@
 /obj/machinery/light/rogue/lanternpost,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield)
+"aov" = (
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town/tavern)
 "aoQ" = (
 /obj/structure/spacevine,
 /turf/open/floor/rogue/dirt/ambush,
@@ -1129,9 +1128,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
-"avF" = (
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
 "awH" = (
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/cobble,
@@ -1170,14 +1166,6 @@
 	},
 /turf/open/floor/rogue/grasscold,
 /area/rogue/indoors/town/tavern)
-"aFy" = (
-/obj/structure/fluff/railing/border{
-	dir = 1;
-	pixel_y = 6
-	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/tavern)
 "aGa" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -1188,6 +1176,16 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave)
+"aHs" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	icon_state = "border";
+	dir = 5
+	},
+/turf/open/floor/rogue/grasscold,
+/area/rogue/indoors/town/tavern)
 "aIP" = (
 /obj/item/reagent_containers/food/snacks/crow{
 	dir = 1
@@ -1238,6 +1236,12 @@
 /obj/item/rogue/instrument/harp,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/tavern)
+"aQU" = (
+/obj/structure/flora/newbranch/connector{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town/tavern)
 "aRe" = (
 /obj/structure/stairs{
 	icon_state = "stairs";
@@ -1272,6 +1276,10 @@
 /obj/structure/fluff/alch,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/rtfield)
+"aXl" = (
+/obj/structure/closet/crate/roguecloset/inn/south,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/tavern)
 "aXS" = (
 /turf/open/floor/rogue/hay,
 /area/rogue/outdoors/rtfield)
@@ -1327,16 +1335,16 @@
 /obj/structure/well/fountain,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
+"bnv" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/tavern)
 "boS" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
-"bpP" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/tavern)
 "bpV" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -1367,10 +1375,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/rtfield)
-"buh" = (
-/obj/structure/closet/crate/drawer/inn,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
 "bvp" = (
 /obj/structure/bed/rogue/inn/wooldouble,
 /turf/open/floor/rogue/blocks,
@@ -1412,6 +1416,10 @@
 /obj/structure/plough,
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/rtfield)
+"bzM" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/outdoors/mountains)
 "bAL" = (
 /obj/structure/flora/roguegrass,
 /obj/effect/decal/mossy{
@@ -1420,6 +1428,30 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
+"bBg" = (
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/reagent_containers/glass/cup/steel{
+	pixel_y = 20;
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/glass/cup/steel{
+	pixel_y = 20;
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/glass/cup/steel{
+	pixel_y = 12;
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/glass/cup/steel{
+	pixel_y = 12;
+	pixel_x = -4
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town/tavern)
+"bBB" = (
+/obj/structure/stairs,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/tavern)
 "bBY" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -1551,9 +1583,8 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "bRV" = (
-/obj/structure/closet/crate/drawer/inn,
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town/tavern)
+/turf/open/floor/rogue/rooftop/green/corner1,
+/area/rogue/outdoors/mountains)
 "bSn" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/snow{
@@ -1613,6 +1644,14 @@
 /obj/structure/fluff/walldeco/stone,
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors)
+"ccw" = (
+/obj/structure/fluff/walldeco/innsign{
+	pixel_x = 32;
+	name = "The Dark Oak";
+	desc = "The inn of the Frozen Summit outpost. Where tales come to begin and die."
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/rtfield)
 "ccX" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors/town)
@@ -1707,10 +1746,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
-"cth" = (
-/obj/structure/fermenting_barrel/blackgoat,
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors/town/tavern)
 "cty" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -1911,11 +1946,20 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/mountains)
+"cYa" = (
+/obj/structure/fluff/railing/fence,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/tile/bath,
+/area/rogue/indoors/town/bath)
 "dba" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/far_travel,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"dcF" = (
+/obj/structure/chair/bench/coucha,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/tavern)
 "dcW" = (
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/rtfield)
@@ -1937,12 +1981,6 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield)
-"dhi" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/tavern)
 "dhx" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/dirt,
@@ -2029,11 +2067,6 @@
 /obj/item/flint,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"doe" = (
-/obj/structure/bed/rogue/inn/double,
-/obj/item/bedsheet/rogue/double_pelt,
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town/tavern)
 "dot" = (
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grasscold,
@@ -2145,10 +2178,6 @@
 "dKn" = (
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/outdoors/rtfield)
-"dKI" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
 "dKO" = (
 /turf/open/floor/rogue/dirt/ambush,
 /area/rogue/under/cave)
@@ -2158,10 +2187,6 @@
 	pixel_y = 28
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/tavern)
-"dLI" = (
-/obj/structure/fermenting_barrel/hagwoodbitter,
-/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
 "dLO" = (
 /obj/structure/bed/rogue/shit,
@@ -2229,13 +2254,6 @@
 /obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
-"dXh" = (
-/obj/structure/roguewindow/openclose/reinforced{
-	dir = 4
-	},
-/obj/structure/roguewindow/openclose/reinforced,
-/turf/open/floor/rogue/twig,
-/area/rogue/indoors/town/tavern)
 "dXm" = (
 /obj/structure/flora/roguetree/snow{
 	icon_state = "tree3"
@@ -2328,6 +2346,9 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
+"elm" = (
+/turf/closed/wall/mineral/rogue/decowood,
+/area/rogue/indoors/town/bath)
 "ely" = (
 /obj/effect/spawner/roguemap/stump,
 /turf/open/floor/rogue/dirt,
@@ -2407,6 +2428,12 @@
 	dir = 4
 	},
 /area/rogue/outdoors/rtfield)
+"eBe" = (
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/town/tavern)
 "eGj" = (
 /obj/structure/stairs,
 /obj/structure/fluff/railing/border{
@@ -2439,33 +2466,9 @@
 /obj/structure/underworld/barrier,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
-"eOR" = (
-/obj/structure/fluff/walldeco/innsign{
-	pixel_x = 32;
-	name = "The Dark Oak";
-	desc = "The inn of the Frozen Summit outpost. Where tales come to begin and die."
-	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
 "eQb" = (
-/obj/structure/mineral_door/wood/deadbolt,
-/turf/open/floor/rogue/wood,
+/turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/indoors/town/tavern)
-"eTO" = (
-/obj/structure/fluff/railing/border{
-	pixel_y = -6
-	},
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 8;
-	pixel_x = -6
-	},
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/clothing/mask/cigarette/pipe,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
 "eUz" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/outdoors/rtfield)
@@ -2485,14 +2488,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"eXQ" = (
-/obj/structure/rack/rogue/shelf/big,
-/obj/item/broom{
-	pixel_y = 10
-	},
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town/tavern)
 "eZs" = (
 /turf/open/water/swamp,
 /area/rogue/under/cave)
@@ -2543,24 +2538,11 @@
 /obj/structure/fluff/walldeco/painting,
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors/town/tavern)
-"fiq" = (
-/obj/structure/roguewindow/openclose/reinforced{
-	dir = 1
-	},
-/turf/open/floor/rogue/twig,
-/area/rogue/indoors/town/tavern)
 "fkd" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/wood,
+/turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/indoors/town/tavern)
 "fki" = (
 /turf/open/transparent/openspace,
-/area/rogue/indoors/town/tavern)
-"fld" = (
-/obj/structure/mineral_door/wood/window,
-/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/tavern)
 "flD" = (
 /obj/structure/table/wood{
@@ -2572,19 +2554,14 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
-"flI" = (
-/obj/structure/closet/crate/chest/neu,
-/obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
-/obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
-/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
-/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
-/obj/item/reagent_containers/food/snacks/grown/oat,
-/obj/item/reagent_containers/food/snacks/grown/oat,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/onion/rogue,
-/obj/item/reagent_containers/food/snacks/grown/onion/rogue,
-/turf/open/floor/rogue/wood,
+"fnE" = (
+/obj/structure/closet/crate/roguecloset/inn,
+/obj/item/clothing/suit/roguetown/shirt/dress,
+/obj/item/clothing/cloak/apron/waist,
+/obj/item/clothing/shoes/roguetown/shortboots,
+/obj/item/clothing/under/roguetown/tights/stockings/white,
+/obj/item/clothing/under/roguetown/tights/stockings/silk/white,
+/turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/tavern)
 "fnO" = (
 /obj/structure/flora/roguetree/stump/log,
@@ -2606,12 +2583,6 @@
 "fsP" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
-"ftV" = (
-/obj/structure/mineral_door/wood/deadbolt{
-	dir = 1
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/tavern)
 "fvg" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/floor/rogue/dirt/road,
@@ -2628,15 +2599,6 @@
 /obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/rtfield)
-"fyl" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 1
-	},
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
 "fzp" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
@@ -2654,6 +2616,13 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/rtfield)
+"fDf" = (
+/obj/structure/roguewindow/openclose/reinforced{
+	dir = 4
+	},
+/obj/structure/roguewindow/openclose/reinforced,
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/town/tavern)
 "fDp" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -2715,9 +2684,11 @@
 	dir = 8
 	},
 /area/rogue/outdoors/mountains)
-"fMf" = (
-/obj/structure/stairs,
-/turf/open/floor/rogue/herringbone,
+"fOe" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/tavern)
 "fOB" = (
 /obj/machinery/light/rogue/oven/south,
@@ -2737,10 +2708,6 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
-"fUp" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/tavern)
 "fUx" = (
 /obj/item/grown/log/tree/stake,
 /turf/closed/mineral/random/rogue/high,
@@ -2771,10 +2738,6 @@
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors)
-"gbf" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/grasscold,
-/area/rogue/indoors/town/tavern)
 "gbn" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town)
@@ -2824,14 +2787,6 @@
 	},
 /turf/open/floor/rogue/snow,
 /area/rogue/outdoors/rtfield)
-"gki" = (
-/obj/structure/fluff/walldeco/innsign{
-	name = "The Dark Oak";
-	desc = "The inn of the Frozen Summit outpost. Where tales come to begin and die.";
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield)
 "gkl" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -2839,18 +2794,21 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors)
 "gkU" = (
-/turf/closed/wall/mineral/rogue/wooddark,
-/area/rogue/indoors/town/tavern)
+/obj/structure/fluff/railing/border{
+	pixel_y = -6
+	},
+/obj/structure/fluff/railing/border{
+	icon_state = "border";
+	dir = 4;
+	pixel_x = 6
+	},
+/obj/structure/fluff/dryingrack,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/outdoors/mountains)
 "glk" = (
 /obj/item/natural/rock,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave)
-"gmN" = (
-/obj/structure/flora/newbranch{
-	dir = 4
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/town/tavern)
 "gog" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/dirt/road,
@@ -2930,21 +2888,31 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town/tavern)
 "gDs" = (
-/obj/structure/fluff/railing/fence,
-/turf/open/floor/rogue/tile/bath,
-/area/rogue/indoors/town/bath)
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "gEm" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/outdoors/rtfield)
-"gEI" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
+"gEs" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/outdoors/mountains)
 "gFz" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/indoors/town/bath)
 "gFA" = (
@@ -2968,6 +2936,12 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/rtfield)
+"gMg" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/outdoors/mountains)
 "gQy" = (
 /obj/machinery/light/rogue/torchholder{
 	icon_state = "torchwall1";
@@ -2993,14 +2967,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
-"gVn" = (
-/obj/structure/fluff/walldeco/innsign{
-	pixel_x = 32;
-	name = "The Dark Oak";
-	desc = "The inn of the Frozen Summit outpost. Where tales come to begin and die."
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/mountains)
 "gVB" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/structure/fluff/railing/wood{
@@ -3022,10 +2988,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors)
-"gWV" = (
-/obj/structure/mineral_door/wood/window,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/tavern)
 "gYF" = (
 /obj/structure/bed/rogue/inn/hay,
 /obj/machinery/light/rogue/wallfire/candle/r,
@@ -3042,6 +3004,12 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town/tavern)
+"hbt" = (
+/obj/structure/roguewindow/openclose/reinforced{
+	dir = 1
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/town/tavern)
 "hdL" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/item/reagent_containers/glass/cup/wooden,
@@ -3056,10 +3024,6 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
-"heg" = (
-/obj/structure/fermenting_barrel,
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors/town/tavern)
 "heZ" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/swamp,
@@ -3071,19 +3035,6 @@
 /obj/item/kitchen/rollingpin,
 /turf/open/floor/rogue/twig/platform,
 /area/rogue/indoors)
-"hgl" = (
-/obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
-"hgT" = (
-/obj/machinery/light/rogue/wallfire{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/tavern)
 "hiA" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/floor/rogue/dirt,
@@ -3153,9 +3104,15 @@
 /area/rogue/outdoors/rtfield)
 "hsN" = (
 /obj/structure/fluff/railing/fence,
-/obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/indoors/town/bath)
+"htb" = (
+/obj/structure/table/wood{
+	icon_state = "longtable";
+	dir = 4
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "huD" = (
 /obj/structure/roguewindow/openclose{
 	dir = 1
@@ -3201,6 +3158,10 @@
 	},
 /turf/open/water/bath,
 /area/rogue/indoors/town/tavern)
+"hHm" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "hHC" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors)
@@ -3229,6 +3190,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach)
+"hMf" = (
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grasscold,
+/area/rogue/indoors/town/tavern)
 "hOv" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -3239,6 +3204,14 @@
 /obj/item/reagent_containers/food/snacks/smallrat/dead,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
+"hPR" = (
+/obj/structure/fluff/railing/border{
+	icon_state = "border";
+	dir = 4;
+	pixel_x = 6
+	},
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/outdoors/mountains)
 "hRp" = (
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/hexstone,
@@ -3278,6 +3251,10 @@
 /obj/structure/roguemachine/atm,
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"hXx" = (
+/obj/structure/mineral_door/wood/window,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "hXE" = (
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/snow{
@@ -3305,6 +3282,10 @@
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave)
+"icX" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/tavern)
 "idt" = (
 /obj/structure/closet/crate/chest{
 	icon_state = "woodchestalt";
@@ -3314,11 +3295,14 @@
 /obj/item/rogueweapon/shovel,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
-"ieV" = (
-/obj/structure/fluff/railing/fence,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/tile/bath,
-/area/rogue/indoors/town/bath)
+"ify" = (
+/obj/structure/fluff/walldeco/innsign{
+	pixel_x = 32;
+	name = "The Dark Oak";
+	desc = "The inn of the Frozen Summit outpost. Where tales come to begin and die."
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/mountains)
 "ifS" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/flora/roguegrass,
@@ -3345,6 +3329,21 @@
 /obj/item/scomstone,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/rtfield)
+"ikx" = (
+/obj/structure/fluff/railing/border{
+	pixel_y = -6
+	},
+/obj/structure/fluff/railing/border{
+	icon_state = "border";
+	dir = 8;
+	pixel_x = -6
+	},
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/clothing/mask/cigarette/pipe,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/outdoors/mountains)
 "ikB" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -3362,6 +3361,12 @@
 "inM" = (
 /turf/closed/wall/mineral/rogue/decowood/vert,
 /area/rogue/outdoors/rtfield)
+"ipT" = (
+/obj/machinery/light/rogue/wallfire{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/tavern)
 "isP" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -3383,12 +3388,6 @@
 	},
 /turf/open/floor/rogue/snow,
 /area/rogue/outdoors/rtfield)
-"izk" = (
-/obj/structure/flora/newbranch{
-	dir = 1
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/town/tavern)
 "izp" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/roguegrass,
@@ -3433,10 +3432,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"iFL" = (
-/obj/structure/roguewindow/openclose/reinforced,
-/turf/open/floor/rogue/twig,
-/area/rogue/indoors/town/tavern)
 "iFR" = (
 /obj/structure/roguerock,
 /turf/open/floor/rogue/snow,
@@ -3490,10 +3485,6 @@
 /obj/structure/flora/roguegrass/thorn_bush,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
-"iNJ" = (
-/obj/structure/chair/bench/coucha,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/tavern)
 "iNO" = (
 /obj/structure/mineral_door/wood{
 	lockid = "house6"
@@ -3554,16 +3545,6 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/rtfield)
-"iWI" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 8
-	},
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town/tavern)
 "iXp" = (
 /obj/structure/bed/rogue/inn,
 /obj/item/bedsheet/rogue/pelt,
@@ -3613,17 +3594,6 @@
 /obj/structure/roguetent,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
-"jem" = (
-/obj/structure/fluff/railing/border{
-	dir = 1;
-	pixel_y = 6
-	},
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/toy/cards/deck,
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/tavern)
 "jfy" = (
 /obj/structure/stairs{
 	icon_state = "stairs";
@@ -3631,9 +3601,6 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/rtfield)
-"jgr" = (
-/turf/closed/wall/mineral/rogue/wooddark/horizontal,
-/area/rogue/indoors/town/tavern)
 "jgZ" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/outdoors/rtfield)
@@ -3644,6 +3611,10 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/rtfield)
+"jmJ" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/tavern)
 "jmO" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -3680,7 +3651,10 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/tavern)
 "jwt" = (
-/turf/closed/wall/mineral/rogue/wooddark/vertical,
+/obj/structure/flora/newbranch{
+	dir = 1
+	},
+/turf/open/transparent/openspace,
 /area/rogue/indoors/town/tavern)
 "jwv" = (
 /obj/structure/fermenting_barrel/hagwoodbitter,
@@ -3716,8 +3690,9 @@
 	},
 /area/rogue/outdoors/rtfield)
 "jBC" = (
-/turf/open/floor/rogue/tile/bath,
-/area/rogue/indoors/town/bath)
+/obj/structure/fluff/wallclock/l,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/tavern)
 "jBO" = (
 /obj/structure/flora/roguegrass/pyroclasticflowers,
 /turf/open/floor/rogue/grasscold,
@@ -3743,10 +3718,6 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
-"jEX" = (
-/obj/structure/closet/crate/roguecloset/inn/south,
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/tavern)
 "jFM" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -3815,7 +3786,6 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town)
 "jRN" = (
-/obj/structure/ladder/unbreakable,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "jSD" = (
@@ -3860,6 +3830,10 @@
 /obj/structure/spacevine,
 /turf/open/floor/rogue/dirt/ambush,
 /area/rogue/under/cave)
+"jZX" = (
+/obj/structure/mineral_door/wood/deadbolt,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "kal" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors)
@@ -3893,6 +3867,12 @@
 /obj/structure/fluff/psycross,
 /turf/open/floor/rogue/snow,
 /area/rogue/outdoors/rtfield)
+"kdM" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "kfp" = (
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/herringbone,
@@ -3983,16 +3963,6 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/rtfield)
-"kyi" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 5
-	},
-/turf/open/floor/rogue/grasscold,
-/area/rogue/indoors/town/tavern)
 "kzb" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/hexstone,
@@ -4046,6 +4016,10 @@
 "kDi" = (
 /turf/open/floor/rogue/rooftop,
 /area/rogue/outdoors/mountains)
+"kEa" = (
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/grasscold,
+/area/rogue/indoors/town/tavern)
 "kEG" = (
 /obj/structure/flora/roguegrass/bush/wall,
 /obj/structure/fluff/railing/fence{
@@ -4055,11 +4029,15 @@
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/rtfield)
 "kFF" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/mundane/puzzlebox/easy,
-/turf/open/floor/rogue/woodturned,
+/obj/structure/closet/crate/chest/neu_iron,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/obj/item/reagent_containers/glass/bottle/rogue/whitewine,
+/obj/item/reagent_containers/glass/bottle/rogue/redwine,
+/obj/item/reagent_containers/glass/bottle/rogue/wine/sourwine,
+/obj/item/reagent_containers/glass/bottle/rogue/wine/sourwine,
+/obj/item/reagent_containers/glass/bottle/rogue/wine/sourwine,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town/tavern)
 "kFM" = (
 /obj/structure/table/wood{
@@ -4092,15 +4070,22 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/rtfield)
+"kGj" = (
+/obj/structure/fluff/railing/border{
+	icon_state = "border";
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	icon_state = "border";
+	dir = 9
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town/tavern)
 "kHj" = (
 /obj/item/grown/log/tree/stake,
 /obj/structure/spacevine,
 /turf/open/water/swamp,
 /area/rogue/under/cave)
-"kHq" = (
-/obj/structure/stairs,
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/tavern)
 "kIk" = (
 /obj/structure/stairs{
 	icon_state = "stairs";
@@ -4137,6 +4122,10 @@
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"kLF" = (
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/tavern)
 "kLI" = (
 /obj/structure/fluff/railing/border{
 	dir = 9;
@@ -4221,13 +4210,6 @@
 /obj/effect/landmark/start/orphan,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
-"kUE" = (
-/obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 8
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
 "kUM" = (
 /obj/structure/stairs{
 	icon_state = "stairs";
@@ -4296,6 +4278,10 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
+"lgI" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/outdoors/mountains)
 "lgQ" = (
 /obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/grassred,
@@ -4311,9 +4297,15 @@
 /turf/open/floor/rogue/grasscold,
 /area/rogue/indoors/town/tavern)
 "ljR" = (
-/obj/structure/mineral_door/wood/deadbolt/shutter,
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/soap/herbal,
+/obj/item/soap/herbal,
+/obj/item/soap/herbal,
+/obj/item/soap/herbal,
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors/town/tavern)
+/area/rogue/indoors/town/bath)
 "lkN" = (
 /obj/structure/bed/rogue/inn/double,
 /obj/item/bedsheet/rogue/double_pelt,
@@ -4387,9 +4379,15 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach)
-"luX" = (
-/obj/structure/fluff/wallclock/l,
-/turf/open/floor/rogue/woodturned,
+"lvD" = (
+/obj/structure/fluff/railing/border{
+	icon_state = "border";
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town/tavern)
 "lvL" = (
 /obj/machinery/light/rogue/torchholder/l,
@@ -4474,16 +4472,6 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/ruinedwood/platform,
 /area/rogue/outdoors/mountains)
-"lHL" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/soap/herbal,
-/obj/item/soap/herbal,
-/obj/item/soap/herbal,
-/obj/item/soap/herbal,
-/turf/open/floor/rogue/twig,
-/area/rogue/indoors/town/bath)
 "lHP" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 1
@@ -4500,6 +4488,18 @@
 /obj/structure/stairs,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
+"lLu" = (
+/obj/structure/fluff/railing/border{
+	pixel_y = -6
+	},
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/outdoors/mountains)
+"lLT" = (
+/obj/structure/closet/crate/chest/neu,
+/obj/item/book/rogue/cooking,
+/obj/item/reagent_containers/glass/bottle/waterskin/milk,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town/tavern)
 "lNx" = (
 /obj/machinery/light/rogue/torchholder{
 	icon_state = "torchwall1";
@@ -4554,6 +4554,10 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave)
+"lXD" = (
+/obj/structure/ladder,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town/tavern)
 "maz" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -4569,10 +4573,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
-"maM" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/tavern)
 "maY" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/twig,
@@ -4611,14 +4611,11 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
 "mke" = (
-/turf/closed/wall/mineral/rogue/decowood,
-/area/rogue/indoors/town/tavern)
-"mkF" = (
-/obj/structure/fluff/railing/border{
-	pixel_y = -6
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = 24
 	},
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town/tavern)
 "mlT" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
@@ -4626,10 +4623,22 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
+"mmQ" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/roguemachine/atm,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/tavern)
 "moC" = (
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"mrD" = (
+/obj/structure/table/wood{
+	icon_state = "longtable";
+	dir = 1
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "mrM" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -4693,10 +4702,6 @@
 	icon_state = "chess"
 	},
 /area/rogue/indoors/town/vault)
-"mzJ" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/tavern)
 "mzO" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -4769,8 +4774,12 @@
 	},
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors)
-"mLx" = (
-/obj/structure/chair/bench/coucha/r,
+"mLy" = (
+/obj/structure/bed/rogue/inn/double,
+/obj/item/bedsheet/rogue/fabric_double,
+/obj/structure/fluff/walldeco/rpainting/crown{
+	pixel_x = 32
+	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
 "mLS" = (
@@ -4838,6 +4847,10 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
+"mWn" = (
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/tavern)
 "mXc" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/transparent/openspace,
@@ -4848,19 +4861,6 @@
 	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/outdoors/rtfield)
-"mXN" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 8;
-	pixel_x = -6
-	},
-/obj/structure/chair/wood/rogue/chair3,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
-"ndE" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town/tavern)
 "neh" = (
 /obj/machinery/light/rogue/campfire,
 /turf/open/floor/rogue/dirt/road,
@@ -4875,25 +4875,6 @@
 	dir = 4
 	},
 /area/rogue/outdoors/beach)
-"nfz" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 9
-	},
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 8;
-	pixel_x = -6
-	},
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
-"ngd" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/tile/bath,
-/area/rogue/indoors/town/bath)
 "ngx" = (
 /obj/structure/stairs/stone{
 	dir = 8
@@ -4964,31 +4945,6 @@
 /obj/effect/landmark/start/vagrant,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
-"nvM" = (
-/obj/machinery/light/rogue/wallfire{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
-"nwg" = (
-/obj/structure/rack/rogue/shelf/big,
-/obj/item/kitchen/spoon,
-/obj/item/kitchen/spoon,
-/obj/item/kitchen/spoon,
-/obj/item/kitchen/spoon,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/cooking/platter,
-/obj/item/cooking/platter,
-/obj/item/cooking/platter,
-/obj/item/kitchen/fork,
-/obj/item/kitchen/fork,
-/obj/item/kitchen/fork,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
 "nww" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -5003,12 +4959,6 @@
 /obj/structure/fluff/railing/border,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/beach)
-"nwP" = (
-/obj/structure/closet/crate/chest/neu,
-/obj/item/book/rogue/cooking,
-/obj/item/reagent_containers/glass/bottle/waterskin/milk,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town/tavern)
 "nym" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
@@ -5040,6 +4990,9 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"nEJ" = (
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/outdoors/mountains)
 "nFv" = (
 /obj/machinery/light/rogue/smelter,
 /turf/open/floor/rogue/hexstone,
@@ -5114,19 +5067,13 @@
 	dir = 4
 	},
 /area/rogue/outdoors/rtfield)
-"ocm" = (
-/obj/structure/flora/newbranch/connector{
-	dir = 8
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/town/tavern)
 "odi" = (
 /obj/structure/far_travel,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
 "odW" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/wood/herringbone,
+/obj/structure/roguewindow/openclose/reinforced,
+/turf/open/floor/rogue/twig,
 /area/rogue/indoors/town/tavern)
 "ogi" = (
 /turf/open/water/ocean{
@@ -5134,6 +5081,14 @@
 	water_reagent = /datum/reagent/water
 	},
 /area/rogue/outdoors/beach)
+"ogv" = (
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	pixel_y = 6
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/tavern)
 "oic" = (
 /obj/structure/roguemachine/atm,
 /turf/open/floor/rogue/hexstone,
@@ -5191,16 +5146,6 @@
 /obj/item/alch/silverdust,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/rtfield)
-"ooQ" = (
-/obj/structure/closet/crate/chest/neu,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/food/snacks/fat,
-/obj/item/reagent_containers/food/snacks/fat,
-/obj/item/reagent_containers/food/snacks/fat,
-/obj/item/reagent_containers/food/snacks/fat,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town/tavern)
 "opX" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -5208,7 +5153,7 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors)
 "osM" = (
-/turf/open/floor/rogue/woodturned,
+/turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/indoors/town/tavern)
 "otl" = (
 /obj/machinery/light/rogue/wallfire{
@@ -5222,6 +5167,10 @@
 	dir = 4
 	},
 /area/rogue/outdoors/mountains)
+"ouD" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/tile/bath,
+/area/rogue/indoors/town/bath)
 "oyy" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/table/wood{
@@ -5259,6 +5208,25 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"oCR" = (
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/kitchen/spoon,
+/obj/item/kitchen/spoon,
+/obj/item/kitchen/spoon,
+/obj/item/kitchen/spoon,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/kitchen/fork,
+/obj/item/kitchen/fork,
+/obj/item/kitchen/fork,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "oDG" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 1
@@ -5307,12 +5275,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"oLH" = (
-/obj/structure/flora/newbranch{
-	dir = 8
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/town/tavern)
 "oLW" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors)
@@ -5348,21 +5310,6 @@
 	color = "e6f2ff"
 	},
 /area/rogue/outdoors/rtfield)
-"oQO" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
 "oSE" = (
 /obj/structure/spacevine,
 /turf/open/floor/rogue/dirt,
@@ -5437,15 +5384,13 @@
 	},
 /area/rogue/outdoors/rtfield)
 "pcR" = (
-/obj/structure/stairs{
-	icon_state = "stairs";
-	dir = 4
-	},
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/tavern)
 "pdz" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood/herringbone,
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 1
+	},
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
 "pdC" = (
 /turf/open/floor/rogue/grasscold,
@@ -5653,6 +5598,10 @@
 	},
 /turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/tavern)
+"pFA" = (
+/obj/structure/chair/bench/coucha/r,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/tavern)
 "pFB" = (
 /obj/structure/fluff/railing/border,
 /obj/machinery/light/rogue/wallfire/candle{
@@ -5674,6 +5623,9 @@
 	color = "e6f2ff"
 	},
 /area/rogue/outdoors/rtfield)
+"pHZ" = (
+/turf/open/floor/rogue/rooftop/green,
+/area/rogue/outdoors/mountains)
 "pIl" = (
 /obj/structure/globe,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -5699,6 +5651,20 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
+"pJx" = (
+/obj/structure/closet/crate/chest/neu,
+/obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
+/obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
+/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
+/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
+/obj/item/reagent_containers/food/snacks/grown/oat,
+/obj/item/reagent_containers/food/snacks/grown/oat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/onion/rogue,
+/obj/item/reagent_containers/food/snacks/grown/onion/rogue,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "pKQ" = (
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors)
@@ -5712,26 +5678,6 @@
 /obj/item/natural/cloth,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/rtfield)
-"pLQ" = (
-/obj/structure/rack/rogue/shelf/big,
-/obj/item/reagent_containers/glass/cup/steel{
-	pixel_y = 20;
-	pixel_x = 4
-	},
-/obj/item/reagent_containers/glass/cup/steel{
-	pixel_y = 20;
-	pixel_x = -4
-	},
-/obj/item/reagent_containers/glass/cup/steel{
-	pixel_y = 12;
-	pixel_x = 4
-	},
-/obj/item/reagent_containers/glass/cup/steel{
-	pixel_y = 12;
-	pixel_x = -4
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town/tavern)
 "pNv" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -5805,9 +5751,20 @@
 /obj/structure/flora/rogueshroom,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
+"qgI" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/tavern)
 "qhe" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
+"qjb" = (
+/obj/structure/table/wood{
+	icon_state = "longtable";
+	dir = 8
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "qjj" = (
 /obj/item/gun/ballistic/arquebus_pistol,
 /obj/effect/decal/remains/human,
@@ -5866,8 +5823,18 @@
 /turf/closed/mineral/random/rogue/high,
 /area/rogue/indoors/town/tavern)
 "qsC" = (
-/obj/structure/chair/wood/rogue,
-/turf/open/floor/rogue/wood,
+/obj/structure/flora/newbranch{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town/tavern)
+"qtZ" = (
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/broom{
+	pixel_y = 10
+	},
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town/tavern)
 "quh" = (
 /obj/structure/mineral_door/wood/deadbolt,
@@ -5925,10 +5892,6 @@
 /obj/structure/fluff/dryingrack,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
-"qBS" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
 "qBT" = (
 /obj/effect/decal/mossy,
 /obj/effect/decal/cobbleedge{
@@ -5981,6 +5944,10 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/cow,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
+"qUa" = (
+/obj/structure/mineral_door/wood/window,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/tavern)
 "qUh" = (
 /obj/structure/fluff/railing/wood{
 	pixel_x = 1;
@@ -6059,6 +6026,11 @@
 	},
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/rtfield)
+"rbr" = (
+/obj/structure/fluff/railing/fence,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/tile/bath,
+/area/rogue/indoors/town/bath)
 "rbt" = (
 /obj/structure/bed/rogue/inn/hay,
 /obj/effect/landmark/start/manorguardsman,
@@ -6086,12 +6058,6 @@
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/floor/rogue/dirt/ambush,
 /area/rogue/under/cave)
-"reG" = (
-/obj/structure/mineral_door/wood/deadbolt{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town/tavern)
 "rhJ" = (
 /obj/structure/closet/crate/chest/wicker{
 	opened = 1
@@ -6129,6 +6095,10 @@
 	color = "e6f2ff"
 	},
 /area/rogue/indoors/town)
+"ryO" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/bath)
 "rAw" = (
 /obj/structure/flora/roguetree/snow,
 /turf/open/floor/rogue/snow{
@@ -6188,7 +6158,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/tavern)
 "rJa" = (
-/turf/open/floor/rogue/wood/herringbone,
+/turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
 "rJC" = (
 /turf/open/floor/rogue/wood,
@@ -6286,9 +6256,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/rtfield)
-"rXE" = (
-/turf/open/floor/rogue/rooftop/green,
-/area/rogue/outdoors/mountains)
 "rYb" = (
 /obj/structure/mineral_door/wood{
 	name = "house i";
@@ -6344,9 +6311,19 @@
 	color = "e6f2ff"
 	},
 /area/rogue/outdoors/rtfield)
+"sct" = (
+/obj/structure/flora/newtree,
+/turf/open/floor/rogue/grasscold,
+/area/rogue/indoors/town/tavern)
 "sdw" = (
 /turf/open/floor/rogue/churchrough,
 /area/rogue/outdoors/rtfield)
+"shJ" = (
+/obj/structure/flora/newbranch{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town/tavern)
 "shW" = (
 /obj/structure/fermenting_barrel/zagul,
 /obj/structure/fluff/railing/border{
@@ -6395,8 +6372,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "skH" = (
-/turf/open/water/bath,
-/area/rogue/indoors/town/bath)
+/obj/structure/closet/crate/drawer/inn,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "slK" = (
 /obj/structure/mineral_door/wood/fancywood{
 	lockid = "house6";
@@ -6486,18 +6464,21 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
-"sAQ" = (
-/obj/structure/bed/rogue/inn/double,
-/obj/item/bedsheet/rogue/fabric_double,
-/obj/structure/fluff/walldeco/rpainting/crown{
-	pixel_x = 32
+"sAL" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/turf/open/floor/rogue/woodturned,
-/area/rogue/indoors/town/tavern)
-"sBx" = (
-/obj/structure/flora/roguegrass,
-/turf/open/floor/rogue/grasscold,
-/area/rogue/indoors/town/tavern)
+/obj/structure/fluff/railing/border{
+	icon_state = "border";
+	dir = 9
+	},
+/obj/structure/fluff/railing/border{
+	icon_state = "border";
+	dir = 8;
+	pixel_x = -6
+	},
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/outdoors/mountains)
 "sCB" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
@@ -6528,16 +6509,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/rtfield)
-"sGJ" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors/town/tavern)
-"sHY" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1
-	},
-/turf/open/floor/rogue/twig,
-/area/rogue/indoors/town/tavern)
 "sJC" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -6570,6 +6541,12 @@
 	dir = 4
 	},
 /area/rogue/outdoors/rtfield)
+"sLw" = (
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/indoors/town/tavern)
 "sNs" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -6580,17 +6557,6 @@
 "sPC" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains)
-"sRQ" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 8
-	},
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 9
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town/tavern)
 "sRV" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach)
@@ -6618,6 +6584,11 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/rtfield)
+"sWA" = (
+/obj/structure/bed/rogue/inn/double,
+/obj/item/bedsheet/rogue/double_pelt,
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/indoors/town/tavern)
 "sXd" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -6714,9 +6685,16 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
+"thV" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/tile/bath,
+/area/rogue/indoors/town/bath)
 "tjx" = (
-/obj/structure/mineral_door/wood/window,
-/turf/open/floor/rogue/wood,
+/obj/structure/fluff/railing/border{
+	icon_state = "border";
+	dir = 8
+	},
+/turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town/tavern)
 "tjy" = (
 /obj/structure/flora/newtree,
@@ -6739,6 +6717,10 @@
 "tlL" = (
 /obj/structure/fluff/walldeco/customflag,
 /turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/town/tavern)
+"tmg" = (
+/obj/structure/chair/wood/rogue,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "tmD" = (
 /obj/item/roguebin/water,
@@ -6809,12 +6791,6 @@
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"tBD" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
 "tCj" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors/town/tavern)
@@ -6830,13 +6806,6 @@
 /obj/structure/rack/rogue/shelf/biggest,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
-"tIR" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 8
-	},
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town/tavern)
 "tKp" = (
 /turf/open/floor/carpet/royalblack,
 /area/rogue/outdoors/rtfield)
@@ -6890,6 +6859,10 @@
 	},
 /turf/open/floor/rogue/grasscold,
 /area/rogue/indoors/town/tavern)
+"tTY" = (
+/obj/structure/closet/crate/drawer/inn,
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/indoors/town/tavern)
 "tVm" = (
 /obj/structure/closet/crate/chest/old_crate,
 /obj/item/rogueweapon/hammer,
@@ -6911,9 +6884,11 @@
 "tXZ" = (
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
-"tYR" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/herringbone,
+"tZu" = (
+/obj/machinery/light/rogue/wallfire{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "ubC" = (
 /turf/open/water/swamp,
@@ -6927,6 +6902,15 @@
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/rtfield)
+"uhv" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/outdoors/mountains)
 "ujo" = (
 /turf/open/floor/rogue/rooftop{
 	dir = 4
@@ -6960,6 +6944,14 @@
 /obj/item/natural/rock,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
+"umU" = (
+/obj/structure/mineral_door/wood/window,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/tavern)
+"unA" = (
+/obj/structure/ladder,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "unS" = (
 /obj/structure/table/wood,
 /obj/structure/mirror{
@@ -6984,8 +6976,8 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield)
 "uro" = (
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town/tavern)
+/turf/open/water/bath,
+/area/rogue/indoors/town/bath)
 "urD" = (
 /obj/structure/mineral_door/wood{
 	name = "house ii";
@@ -7045,10 +7037,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave)
-"uzE" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
 "uBR" = (
 /turf/closed/mineral/random/rogue/med,
 /area/rogue/under/cave)
@@ -7065,6 +7053,14 @@
 	icon_state = "rockwd";
 	dir = 1
 	},
+/area/rogue/outdoors/rtfield)
+"uGV" = (
+/obj/structure/fluff/walldeco/innsign{
+	name = "The Dark Oak";
+	desc = "The inn of the Frozen Summit outpost. Where tales come to begin and die.";
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
 "uIM" = (
 /obj/structure/table/wood{
@@ -7152,16 +7148,6 @@
 	},
 /turf/open/floor/rogue/snow,
 /area/rogue/outdoors/rtfield)
-"uZf" = (
-/obj/structure/ladder/unbreakable,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town/tavern)
-"vby" = (
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = 24
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/town/tavern)
 "vcT" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf,
 /turf/open/floor/rogue/snow,
@@ -7183,9 +7169,10 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
-"vhl" = (
-/turf/open/floor/rogue/rooftop/green/corner1,
-/area/rogue/outdoors/mountains)
+"vhe" = (
+/obj/structure/stairs,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/tavern)
 "vir" = (
 /obj/machinery/light/rogue/smelter/great,
 /obj/structure/fluff/railing/wood{
@@ -7274,8 +7261,7 @@
 /turf/open/floor/rogue/dirt/ambush,
 /area/rogue/outdoors/mountains)
 "vuK" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/roguemachine/atm,
+/obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/tavern)
 "vwR" = (
@@ -7325,35 +7311,10 @@
 /obj/structure/spacevine,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave)
-"vGf" = (
-/obj/structure/closet/crate/chest/neu,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/powder/salt,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/reagent_containers/food/snacks/fat,
-/obj/item/reagent_containers/food/snacks/fat,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
 "vGx" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
-"vHb" = (
-/obj/structure/fluff/railing/border{
-	pixel_y = -6
-	},
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 4;
-	pixel_x = 6
-	},
-/obj/structure/fluff/dryingrack,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
 "vIa" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/ruinedwood/platform,
@@ -7376,6 +7337,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/rtfield)
+"vJD" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/indoors/town/tavern)
 "vJT" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/hoe,
@@ -7462,13 +7427,6 @@
 /obj/item/reagent_containers/glass/bucket/pot/stone,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
-"vUE" = (
-/obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 4
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town/tavern)
 "vVR" = (
 /obj/structure/fluff/walldeco/maidensigil,
 /turf/open/floor/rogue/tile/bath,
@@ -7525,6 +7483,10 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/rtfield)
+"wbR" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/tavern)
 "wbS" = (
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/dirt/road,
@@ -7590,14 +7552,6 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/snow,
 /area/rogue/outdoors/rtfield)
-"wkF" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 4;
-	pixel_x = 6
-	},
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
 "wkG" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/beach)
@@ -7825,14 +7779,12 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
-"wYc" = (
-/obj/structure/closet/crate/roguecloset/inn,
-/obj/item/clothing/suit/roguetown/shirt/dress,
-/obj/item/clothing/cloak/apron/waist,
-/obj/item/clothing/shoes/roguetown/shortboots,
-/obj/item/clothing/under/roguetown/tights/stockings/white,
-/obj/item/clothing/under/roguetown/tights/stockings/silk/white,
-/turf/open/floor/rogue/ruinedwood/herringbone,
+"wYH" = (
+/obj/structure/stairs{
+	icon_state = "stairs";
+	dir = 4
+	},
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "wZe" = (
 /obj/effect/landmark/start/veteran,
@@ -7870,6 +7822,17 @@
 	dir = 1
 	},
 /area/rogue/outdoors/rtfield)
+"xdS" = (
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	pixel_y = 6
+	},
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/toy/cards/deck,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/tavern)
 "xeq" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/snow,
@@ -7914,7 +7877,7 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "xki" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "xlq" = (
@@ -7968,6 +7931,14 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave)
+"xnN" = (
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	pixel_y = 6
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/tavern)
 "xoz" = (
 /obj/structure/roguemachine/steward,
 /obj/structure/table/wood,
@@ -8013,6 +7984,13 @@
 /obj/structure/well,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/rtfield)
+"xyE" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/mundane/puzzlebox/easy,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/tavern)
 "xzP" = (
 /obj/structure/fluff/railing/wood,
 /obj/structure/fluff/railing/wood{
@@ -8029,9 +8007,10 @@
 "xAZ" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/tavern)
-"xBr" = (
-/turf/closed/wall/mineral/rogue/decowood,
-/area/rogue/indoors/town/bath)
+"xBg" = (
+/obj/structure/fermenting_barrel/hagwoodbitter,
+/turf/open/floor/rogue/ruinedwood/turned,
+/area/rogue/indoors/town/tavern)
 "xBE" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/snow{
@@ -8068,9 +8047,18 @@
 	color = "e6f2ff"
 	},
 /area/rogue/outdoors/rtfield)
-"xEO" = (
-/obj/structure/flora/newtree,
-/turf/open/floor/rogue/grasscold,
+"xEW" = (
+/obj/structure/closet/crate/chest/neu,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/fat,
+/obj/item/reagent_containers/food/snacks/fat,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "xHh" = (
 /obj/machinery/light/rogue/torchholder{
@@ -8087,7 +8075,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave)
 "xIP" = (
-/turf/open/floor/rogue/wood,
+/turf/closed/wall/mineral/rogue/wooddark,
+/area/rogue/indoors/town/tavern)
+"xJZ" = (
+/obj/structure/fermenting_barrel,
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
 "xLL" = (
 /obj/structure/stairs{
@@ -8140,6 +8132,20 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
+"xSc" = (
+/obj/structure/closet/crate/chest/neu,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/food/snacks/fat,
+/obj/item/reagent_containers/food/snacks/fat,
+/obj/item/reagent_containers/food/snacks/fat,
+/obj/item/reagent_containers/food/snacks/fat,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town/tavern)
+"xUT" = (
+/obj/structure/fermenting_barrel/blackgoat,
+/turf/open/floor/rogue/ruinedwood/turned,
+/area/rogue/indoors/town/tavern)
 "xWm" = (
 /obj/machinery/light/rogue/cauldron,
 /turf/open/floor/rogue/blocks,
@@ -8182,17 +8188,6 @@
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/outdoors/rtfield)
-"yfX" = (
-/obj/structure/closet/crate/chest/neu_iron,
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/obj/item/reagent_containers/glass/bottle/rogue/whitewine,
-/obj/item/reagent_containers/glass/bottle/rogue/redwine,
-/obj/item/reagent_containers/glass/bottle/rogue/wine/sourwine,
-/obj/item/reagent_containers/glass/bottle/rogue/wine/sourwine,
-/obj/item/reagent_containers/glass/bottle/rogue/wine/sourwine,
-/turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town/tavern)
 "ygb" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -8211,12 +8206,8 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/rtfield)
 "ygR" = (
-/obj/structure/fluff/railing/border{
-	dir = 1;
-	pixel_y = 6
-	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/wood/herringbone,
+/obj/structure/mineral_door/wood/deadbolt/shutter,
+/turf/open/floor/rogue/twig,
 /area/rogue/indoors/town/tavern)
 "ygT" = (
 /obj/effect/decal/cleanable/blood,
@@ -8226,6 +8217,15 @@
 /obj/structure/flora/roguegrass/swampweed,
 /turf/open/floor/rogue/dirt/ambush,
 /area/rogue/under/cave)
+"yiK" = (
+/obj/structure/fluff/railing/border{
+	icon_state = "border";
+	dir = 8;
+	pixel_x = -6
+	},
+/obj/structure/chair/wood/rogue/chair3,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/outdoors/mountains)
 "yjc" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/mountains)
@@ -43808,7 +43808,7 @@ fLa
 quh
 fsP
 fsP
-eOR
+ccw
 fsP
 fsP
 fsP
@@ -43965,15 +43965,15 @@ rYw
 haj
 haj
 maY
-mke
+eQb
 pLn
 pLn
-mke
+eQb
 maY
-mke
-mke
-mke
-mke
+eQb
+eQb
+eQb
+eQb
 haj
 haj
 abe
@@ -44120,14 +44120,14 @@ abV
 iSL
 rYw
 haj
-sBx
+hMf
 cOL
-gbf
+kEa
 vqm
 vqm
 acj
 klJ
-xIP
+jRN
 hdL
 wWO
 shW
@@ -44283,13 +44283,13 @@ ifS
 vqm
 vqm
 acj
-hgl
-xIP
-xIP
-xIP
-xIP
-pcR
-mke
+mrD
+jRN
+jRN
+jRN
+jRN
+wYH
+eQb
 mVe
 fsP
 fsP
@@ -44435,19 +44435,19 @@ iSL
 iSL
 maY
 feq
-xEO
+sct
 pFB
 vqm
 vqm
 vqm
-mke
-vUE
+eQb
+htb
 uIM
 uIM
-kUE
-mke
-mke
-gki
+qjb
+eQb
+eQb
+uGV
 fsP
 fsP
 mVe
@@ -44591,19 +44591,19 @@ cty
 iSL
 iSL
 maY
-kyi
+aHs
 aEv
 tTH
 vqm
 vqm
 vqm
-tYR
+qgI
 acj
 acj
 acj
 acj
-tYR
-mke
+qgI
+eQb
 mVe
 fsP
 fsP
@@ -44747,14 +44747,14 @@ abV
 abV
 iSL
 iSL
-mke
+eQb
 vqm
 vqm
 vqm
 vqm
 vqm
 vqm
-fUp
+kLF
 vqm
 vqm
 vqm
@@ -44904,13 +44904,13 @@ rDz
 abV
 iSL
 iSL
-mke
-bpP
-fMf
-mke
+eQb
 vuK
+vhe
+eQb
+mmQ
 vqm
-maM
+icX
 haj
 haj
 haj
@@ -45063,17 +45063,17 @@ vJn
 iSL
 haj
 vqm
-fMf
-mke
-xBr
+vhe
+eQb
+elm
 cgj
-xBr
+elm
 aqr
-ngd
-skH
-skH
-skH
-hsN
+ouD
+uro
+uro
+uro
+rbr
 fRr
 mVe
 fsP
@@ -45227,10 +45227,10 @@ aCU
 vFx
 aqr
 vVR
-skH
-skH
-skH
-gDs
+uro
+uro
+uro
+hsN
 mVe
 fsP
 fsP
@@ -45383,11 +45383,11 @@ tOE
 aCU
 vFx
 sux
-jBC
-skH
-skH
-skH
-gDs
+gFz
+uro
+uro
+uro
+hsN
 mVe
 fsP
 fsP
@@ -45535,16 +45535,16 @@ xqr
 xqr
 xqr
 lnn
-xBr
+elm
 tOE
 aCU
 vFx
 sux
-jBC
-skH
-skH
-skH
-gDs
+gFz
+uro
+uro
+uro
+hsN
 fRr
 fsP
 fsP
@@ -45694,14 +45694,14 @@ xqr
 lnn
 aqr
 tOE
-agk
-lHL
+ryO
+ljR
 aqr
 vVR
-skH
-skH
-skH
-gDs
+uro
+uro
+uro
+hsN
 fRr
 mVe
 fsP
@@ -45851,14 +45851,14 @@ lnn
 lnn
 aqr
 aqr
-xBr
+elm
 aqr
 aqr
+thV
 gFz
-jBC
-jBC
-jBC
-ieV
+gFz
+gFz
+cYa
 mVe
 fsP
 fsP
@@ -68148,7 +68148,7 @@ sPC
 sPC
 sPC
 sPC
-gVn
+ify
 sPC
 sPC
 sPC
@@ -68301,15 +68301,15 @@ tXZ
 haj
 haj
 kjj
-mke
-mke
+eQb
+eQb
 kjj
-fld
-mke
-mke
-mke
-mke
-mke
+qUa
+eQb
+eQb
+eQb
+eQb
+eQb
 haj
 haj
 tXZ
@@ -68457,13 +68457,13 @@ tXZ
 tXZ
 haj
 fki
-oLH
+shJ
 fki
-ygR
-rJa
-rJa
-mzJ
-mke
+xnN
+pcR
+pcR
+wbR
+eQb
 xfP
 jvD
 xbj
@@ -68612,20 +68612,20 @@ kDi
 kDi
 tXZ
 tXZ
-mke
+eQb
 fki
-ocm
+aQU
 fki
-aFy
-odW
-rJa
-rJa
-ljR
-xIP
-xIP
+ogv
+mWn
+pcR
+pcR
+ygR
+jRN
+jRN
 oyy
 fki
-mke
+eQb
 tXZ
 tXZ
 tXZ
@@ -68769,20 +68769,20 @@ kDi
 kDi
 tXZ
 tXZ
-iFL
-izk
+odW
+jwt
 tjy
-vby
-jem
-dhi
-rJa
-rJa
 mke
-nwg
-xIP
-xIP
+xdS
+fOe
 pcR
-fiq
+pcR
+eQb
+oCR
+jRN
+jRN
+wYH
+hbt
 tXZ
 tXZ
 tXZ
@@ -68926,20 +68926,20 @@ kDi
 kDi
 tXZ
 tXZ
-dXh
+fDf
 fki
-gmN
+qsC
 fki
-aFy
-odW
-rJa
-rJa
-mke
+ogv
+mWn
+pcR
+pcR
+eQb
 ssA
-xIP
-xIP
 jRN
-mke
+jRN
+unA
+eQb
 tXZ
 tXZ
 tXZ
@@ -69083,19 +69083,19 @@ kDi
 kDi
 tXZ
 tXZ
-iFL
+odW
 fki
 fki
 fki
 pDl
-rJa
-rJa
-rJa
-tjx
-qBS
+pcR
+pcR
+pcR
+hXx
 xki
-flI
-vGf
+gDs
+pJx
+xEW
 haj
 tXZ
 tXZ
@@ -69240,18 +69240,18 @@ kDi
 kDi
 tXZ
 tXZ
-mke
+eQb
 fki
 fki
 eGj
-rJa
-rJa
-rJa
-rJa
-mke
-mke
-mke
-mke
+pcR
+pcR
+pcR
+pcR
+eQb
+eQb
+eQb
+eQb
 haj
 haj
 tXZ
@@ -69400,17 +69400,17 @@ tXZ
 haj
 fki
 fki
-kHq
-sGJ
-rJa
-rJa
-rJa
-eQb
-xIP
-dKI
-xIP
-sHY
-rXE
+bBB
+bnv
+pcR
+pcR
+pcR
+jZX
+jRN
+hHm
+jRN
+eBe
+pHZ
 tXZ
 tXZ
 tXZ
@@ -69556,18 +69556,18 @@ tXZ
 tXZ
 haj
 haj
-mke
-mke
-mke
-mke
-rJa
-rJa
-mke
-buh
+eQb
+eQb
+eQb
+eQb
+pcR
+pcR
+eQb
+skH
 iXp
-fkd
-mke
-rXE
+kdM
+eQb
+pHZ
 tXZ
 tXZ
 tXZ
@@ -69710,21 +69710,21 @@ kDi
 kDi
 kDi
 tXZ
-nfz
-gEI
-gWV
-osM
-luX
-osM
-ftV
+sAL
+bzM
+umU
 rJa
+jBC
 rJa
-mke
-mke
-mke
-mke
-mke
-rXE
+pdz
+pcR
+pcR
+eQb
+eQb
+eQb
+eQb
+eQb
+pHZ
 tXZ
 tXZ
 tXZ
@@ -69867,21 +69867,21 @@ tXZ
 tXZ
 tXZ
 tXZ
-tBD
-avF
-mke
-iNJ
-kFF
-osM
-mke
-pdz
+gMg
+nEJ
+eQb
+dcF
+xyE
 rJa
 eQb
-xIP
-qsC
-fkd
-sHY
-rXE
+jmJ
+pcR
+jZX
+jRN
+tmg
+kdM
+eBe
+pHZ
 tXZ
 tXZ
 tXZ
@@ -70024,21 +70024,21 @@ tXZ
 tXZ
 tXZ
 tXZ
-oQO
-fyl
-mke
-mLx
-osM
-osM
-mke
+gEs
+uhv
+eQb
+pFA
 rJa
 rJa
-mke
-nvM
-xIP
-xIP
-mke
-rXE
+eQb
+pcR
+pcR
+eQb
+tZu
+jRN
+jRN
+eQb
+pHZ
 tXZ
 tXZ
 tXZ
@@ -70183,19 +70183,19 @@ tXZ
 tXZ
 tXZ
 tXZ
-mke
-hgT
-osM
-osM
-mke
+eQb
+ipT
 rJa
 rJa
-mke
+eQb
+pcR
+pcR
+eQb
 pof
 iCx
-xIP
+jRN
 haj
-rXE
+pHZ
 tXZ
 tXZ
 tXZ
@@ -70340,19 +70340,19 @@ tXZ
 tXZ
 tXZ
 tXZ
-mke
-jEX
-sAQ
-osM
-mke
-mke
-mke
-mke
-mke
-mke
+eQb
+aXl
+mLy
+rJa
+eQb
+eQb
+eQb
+eQb
+eQb
+eQb
 haj
 haj
-vhl
+bRV
 tXZ
 tXZ
 tXZ
@@ -70497,11 +70497,11 @@ tXZ
 tXZ
 tXZ
 tXZ
-mke
-mke
-mke
-mke
-mke
+eQb
+eQb
+eQb
+eQb
+eQb
 tXZ
 tXZ
 tXZ
@@ -92486,11 +92486,11 @@ kDi
 kDi
 kDi
 kDi
-gkU
-jgr
-gkU
-jgr
-gkU
+xIP
+osM
+xIP
+osM
+xIP
 tXZ
 tXZ
 tXZ
@@ -92643,11 +92643,11 @@ kDi
 kDi
 kDi
 kDi
-gkU
-cth
-dLI
-heg
-gkU
+xIP
+xUT
+xBg
+xJZ
+xIP
 tXZ
 tXZ
 tXZ
@@ -92800,11 +92800,11 @@ kDi
 kDi
 kDi
 kDi
-gkU
-sRQ
-tIR
-iWI
-gkU
+xIP
+kGj
+tjx
+lvD
+xIP
 tXZ
 tXZ
 tXZ
@@ -92957,11 +92957,11 @@ kDi
 kDi
 kDi
 kDi
-jwt
-eXQ
-uro
-ooQ
-jwt
+fkd
+qtZ
+aov
+xSc
+fkd
 tXZ
 tXZ
 tXZ
@@ -93114,11 +93114,11 @@ kDi
 kDi
 kDi
 kDi
-gkU
-pLQ
-uro
-nwP
-gkU
+xIP
+bBg
+aov
+lLT
+xIP
 tXZ
 tXZ
 tXZ
@@ -93271,11 +93271,11 @@ kDi
 kDi
 kDi
 kDi
-gkU
-yfX
-uro
-uZf
-gkU
+xIP
+kFF
+aov
+lXD
+xIP
 tXZ
 tXZ
 tXZ
@@ -93428,13 +93428,13 @@ kDi
 kDi
 kDi
 kDi
-gkU
-jgr
-reG
-jgr
-gkU
-mXN
-eTO
+xIP
+osM
+sLw
+osM
+xIP
+yiK
+ikx
 tXZ
 tXZ
 tXZ
@@ -93584,14 +93584,14 @@ kDi
 kDi
 kDi
 kDi
-gkU
-gkU
-ndE
+xIP
+xIP
+vJD
 smO
 smO
-gkU
-avF
-mkF
+xIP
+nEJ
+lLu
 tXZ
 tXZ
 tXZ
@@ -93741,14 +93741,14 @@ kDi
 kDi
 kDi
 kDi
-jwt
-wYc
+fkd
+fnE
 smO
 smO
 smO
-jwt
-uzE
-mkF
+fkd
+lgI
+lLu
 tXZ
 tXZ
 tXZ
@@ -93898,14 +93898,14 @@ kDi
 kDi
 kDi
 kDi
-gkU
-gkU
-bRV
-doe
+xIP
+xIP
+tTY
+sWA
 smO
-gWV
-wkF
-vHb
+umU
+hPR
+gkU
 tXZ
 tXZ
 tXZ
@@ -94056,11 +94056,11 @@ kDi
 kDi
 kDi
 kDi
-gkU
-jgr
-gkU
-jgr
-gkU
+xIP
+osM
+xIP
+osM
+xIP
 tXZ
 tXZ
 tXZ

--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -30,7 +30,7 @@
 "aaf" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobble,
-/area/rogue)
+/area/rogue/outdoors/rtfield)
 "aag" = (
 /obj/effect/landmark/start/farmer,
 /turf/open/floor/rogue/cobblerock,
@@ -513,7 +513,8 @@
 "abL" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
-	dir = 4
+	dir = 4;
+	pixel_x = 6
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/rtfield)
@@ -528,7 +529,8 @@
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
-	dir = 4
+	dir = 4;
+	pixel_x = 6
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/rtfield)
@@ -566,7 +568,8 @@
 	},
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
-	dir = 4
+	dir = 4;
+	pixel_x = 6
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/rtfield)
@@ -683,7 +686,7 @@
 "acj" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town/tavern)
 "ack" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 1
@@ -726,7 +729,9 @@
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
 	},
-/obj/structure/fluff/millstone,
+/obj/structure/fluff/millstone{
+	pixel_y = 10
+	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "acr" = (
@@ -738,8 +743,13 @@
 /area/rogue/outdoors/mountains)
 "act" = (
 /obj/structure/closet/crate/roguecloset,
-/obj/item/cooking/pan,
-/obj/item/rogueweapon/huntingknife/chefknife,
+/obj/item/cooking/pan{
+	pixel_y = 28
+	},
+/obj/item/rogueweapon/huntingknife/chefknife{
+	pixel_y = 6;
+	pixel_x = -10
+	},
 /obj/item/reagent_containers/glass/bucket/pot,
 /obj/item/kitchen/rollingpin,
 /obj/item/reagent_containers/glass/cup/wooden,
@@ -926,7 +936,9 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
 "acW" = (
-/obj/structure/fluff/millstone,
+/obj/structure/fluff/millstone{
+	pixel_y = 10
+	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
 "acX" = (
@@ -1035,6 +1047,10 @@
 /obj/structure/fluff/dryingrack,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/rtfield)
+"agk" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/bath)
 "ahG" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
@@ -1080,9 +1096,8 @@
 /turf/open/floor/rogue/snow,
 /area/rogue/outdoors/rtfield)
 "aqr" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/twig,
-/area/rogue/outdoors/rtfield)
+/turf/closed/wall/mineral/rogue/stonebrick,
+/area/rogue/indoors/town/bath)
 "aqs" = (
 /obj/structure/stairs{
 	dir = 8
@@ -1114,6 +1129,9 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
+"avF" = (
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/outdoors/mountains)
 "awH" = (
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/cobble,
@@ -1140,19 +1158,26 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
 "aCU" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/obj/machinery/light/rogue/firebowl/stump,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/beach)
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/bath)
 "aEv" = (
-/obj/structure/flora/newbranch{
+/obj/structure/fluff/railing/border{
 	dir = 4
 	},
-/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/newbranch/leafless{
+	dir = 4
+	},
 /turf/open/floor/rogue/grasscold,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town/tavern)
+"aFy" = (
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	pixel_y = 6
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/tavern)
 "aGa" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -1219,7 +1244,9 @@
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	dir = 9
+	dir = 9;
+	pixel_y = -26;
+	pixel_x = -6
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
@@ -1306,6 +1333,10 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
+"bpP" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/tavern)
 "bpV" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -1336,6 +1367,10 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/rtfield)
+"buh" = (
+/obj/structure/closet/crate/drawer/inn,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "bvp" = (
 /obj/structure/bed/rogue/inn/wooldouble,
 /turf/open/floor/rogue/blocks,
@@ -1516,13 +1551,9 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "bRV" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/item/clothing/mask/rogue/skullmask,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/obj/structure/closet/crate/drawer/inn,
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/indoors/town/tavern)
 "bSn" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/snow{
@@ -1601,7 +1632,7 @@
 "cgj" = (
 /obj/structure/mineral_door/wood/fancywood,
 /turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town/bath)
 "chq" = (
 /obj/structure/rack/rogue/shelf/big,
 /obj/item/rogueweapon/pitchfork{
@@ -1676,6 +1707,10 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
+"cth" = (
+/obj/structure/fermenting_barrel/blackgoat,
+/turf/open/floor/rogue/ruinedwood/turned,
+/area/rogue/indoors/town/tavern)
 "cty" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -1749,14 +1784,18 @@
 /area/rogue/outdoors/rtfield)
 "cBU" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/fluff/millstone,
+/obj/structure/fluff/millstone{
+	pixel_y = 10
+	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "cEg" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
 	},
-/obj/item/cooking/pan,
+/obj/item/cooking/pan{
+	pixel_y = 28
+	},
 /turf/open/floor/rogue/twig/platform,
 /area/rogue/indoors)
 "cEq" = (
@@ -1814,10 +1853,8 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/rtfield)
 "cOL" = (
-/obj/structure/fluff/railing/wood,
-/obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/grasscold,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town/tavern)
 "cOM" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
 /turf/open/floor/rogue/naturalstone,
@@ -1900,6 +1937,12 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield)
+"dhi" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/tavern)
 "dhx" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/dirt,
@@ -1934,7 +1977,9 @@
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	dir = 9
+	dir = 9;
+	pixel_y = -26;
+	pixel_x = -6
 	},
 /turf/open/floor/rogue/snow{
 	color = "e6f2ff"
@@ -1952,8 +1997,13 @@
 /area/rogue/outdoors/rtfield)
 "dkE" = (
 /obj/structure/closet/crate/roguecloset,
-/obj/item/rogueweapon/huntingknife/cleaver,
-/obj/item/rogueweapon/huntingknife/chefknife,
+/obj/item/rogueweapon/huntingknife/cleaver{
+	pixel_y = 28
+	},
+/obj/item/rogueweapon/huntingknife/chefknife{
+	pixel_y = 6;
+	pixel_x = -10
+	},
 /obj/item/kitchen/spoon,
 /obj/item/kitchen/spoon,
 /obj/item/kitchen/spoon,
@@ -1979,6 +2029,11 @@
 /obj/item/flint,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"doe" = (
+/obj/structure/bed/rogue/inn/double,
+/obj/item/bedsheet/rogue/double_pelt,
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/indoors/town/tavern)
 "dot" = (
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grasscold,
@@ -2058,7 +2113,8 @@
 /area/rogue/outdoors/rtfield)
 "dGC" = (
 /obj/structure/table/wood{
-	icon_state = "longtable"
+	icon_state = "longtable";
+	dir = 4
 	},
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /obj/item/clothing/neck/roguetown/psicross/astrata,
@@ -2089,13 +2145,23 @@
 "dKn" = (
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/outdoors/rtfield)
+"dKI" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "dKO" = (
 /turf/open/floor/rogue/dirt/ambush,
 /area/rogue/under/cave)
 "dKZ" = (
 /obj/machinery/light/rogue/hearth,
-/obj/item/cooking/pan,
+/obj/item/cooking/pan{
+	pixel_y = 28
+	},
 /turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/tavern)
+"dLI" = (
+/obj/structure/fermenting_barrel/hagwoodbitter,
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
 "dLO" = (
 /obj/structure/bed/rogue/shit,
@@ -2163,6 +2229,13 @@
 /obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
+"dXh" = (
+/obj/structure/roguewindow/openclose/reinforced{
+	dir = 4
+	},
+/obj/structure/roguewindow/openclose/reinforced,
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/town/tavern)
 "dXm" = (
 /obj/structure/flora/roguetree/snow{
 	icon_state = "tree3"
@@ -2181,7 +2254,8 @@
 "dZj" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
-	dir = 4
+	dir = 4;
+	pixel_x = 6
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -2239,7 +2313,9 @@
 /area/rogue/under/cave)
 "ejK" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/fluff/millstone,
+/obj/structure/fluff/millstone{
+	pixel_y = 10
+	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/rtfield)
 "ekN" = (
@@ -2332,9 +2408,19 @@
 	},
 /area/rogue/outdoors/rtfield)
 "eGj" = (
-/obj/structure/mineral_door/wood/donjon/stone,
-/turf/open/floor/rogue/twig/platform,
-/area/rogue/outdoors/mountains)
+/obj/structure/stairs,
+/obj/structure/fluff/railing/border{
+	icon_state = "border";
+	dir = 8;
+	pixel_x = -6
+	},
+/obj/structure/fluff/railing/border{
+	dir = 9;
+	pixel_y = -26;
+	pixel_x = -6
+	},
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/tavern)
 "eHT" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -2353,30 +2439,41 @@
 /obj/structure/underworld/barrier,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
+"eOR" = (
+/obj/structure/fluff/walldeco/innsign{
+	pixel_x = 32;
+	name = "The Dark Oak";
+	desc = "The inn of the Frozen Summit outpost. Where tales come to begin and die."
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/rtfield)
 "eQb" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/obj/structure/closet/crate/chest/neu_fancy,
-/obj/item/kitchen/spoon,
-/obj/item/kitchen/spoon,
-/obj/item/kitchen/spoon,
-/obj/item/kitchen/spoon,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/kitchen/spoon,
-/obj/item/kitchen/spoon,
-/obj/item/kitchen/spoon,
-/obj/item/kitchen/spoon,
-/turf/open/floor/rogue/herringbone,
+/obj/structure/mineral_door/wood/deadbolt,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
+"eTO" = (
+/obj/structure/fluff/railing/border{
+	pixel_y = -6
+	},
+/obj/structure/fluff/railing/border{
+	icon_state = "border";
+	dir = 8;
+	pixel_x = -6
+	},
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/clothing/mask/cigarette/pipe,
+/turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/outdoors/mountains)
 "eUz" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/outdoors/rtfield)
 "eUQ" = (
 /obj/structure/fluff/railing/border{
-	dir = 9
+	dir = 9;
+	pixel_y = -26;
+	pixel_x = -6
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave)
@@ -2388,6 +2485,14 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"eXQ" = (
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/broom{
+	pixel_y = 10
+	},
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town/tavern)
 "eZs" = (
 /turf/open/water/swamp,
 /area/rogue/under/cave)
@@ -2425,12 +2530,11 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
 "feq" = (
-/obj/structure/stairs{
-	icon_state = "stairs";
-	dir = 4
+/obj/structure/flora/newbranch/leafless{
+	dir = 1
 	},
 /turf/open/floor/rogue/grasscold,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town/tavern)
 "ffT" = (
 /obj/machinery/light/rogue/campfire/densefire,
 /turf/open/floor/rogue/dirt/road,
@@ -2439,27 +2543,49 @@
 /obj/structure/fluff/walldeco/painting,
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"fiq" = (
+/obj/structure/roguewindow/openclose/reinforced{
+	dir = 1
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/town/tavern)
 "fkd" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/indoors)
+/area/rogue/indoors/town/tavern)
 "fki" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/obj/structure/stairs{
-	icon_state = "stairs";
-	dir = 4
-	},
 /turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/tavern)
+"fld" = (
+/obj/structure/mineral_door/wood/window,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/tavern)
 "flD" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
 	},
-/obj/item/rogueweapon/huntingknife/chefknife,
+/obj/item/rogueweapon/huntingknife/chefknife{
+	pixel_y = 6;
+	pixel_x = -10
+	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
+"flI" = (
+/obj/structure/closet/crate/chest/neu,
+/obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
+/obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
+/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
+/obj/item/reagent_containers/food/snacks/grown/potato/rogue,
+/obj/item/reagent_containers/food/snacks/grown/oat,
+/obj/item/reagent_containers/food/snacks/grown/oat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/onion/rogue,
+/obj/item/reagent_containers/food/snacks/grown/onion/rogue,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "fnO" = (
 /obj/structure/flora/roguetree/stump/log,
 /turf/open/floor/rogue/dirt/road,
@@ -2480,6 +2606,12 @@
 "fsP" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
+"ftV" = (
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 1
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/tavern)
 "fvg" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/floor/rogue/dirt/road,
@@ -2496,6 +2628,15 @@
 /obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/rtfield)
+"fyl" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/chair/wood/rogue/fancy{
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/outdoors/mountains)
 "fzp" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
@@ -2563,7 +2704,9 @@
 /area/rogue/outdoors/rtfield)
 "fLa" = (
 /obj/structure/fluff/railing/border{
-	dir = 9
+	dir = 9;
+	pixel_y = -26;
+	pixel_x = -6
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/rtfield)
@@ -2572,6 +2715,10 @@
 	dir = 8
 	},
 /area/rogue/outdoors/mountains)
+"fMf" = (
+/obj/structure/stairs,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/tavern)
 "fOB" = (
 /obj/machinery/light/rogue/oven/south,
 /turf/open/floor/rogue/cobble,
@@ -2590,6 +2737,10 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
+"fUp" = (
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/tavern)
 "fUx" = (
 /obj/item/grown/log/tree/stake,
 /turf/closed/mineral/random/rogue/high,
@@ -2620,6 +2771,10 @@
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors)
+"gbf" = (
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/grasscold,
+/area/rogue/indoors/town/tavern)
 "gbn" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town)
@@ -2669,6 +2824,14 @@
 	},
 /turf/open/floor/rogue/snow,
 /area/rogue/outdoors/rtfield)
+"gki" = (
+/obj/structure/fluff/walldeco/innsign{
+	name = "The Dark Oak";
+	desc = "The inn of the Frozen Summit outpost. Where tales come to begin and die.";
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/rtfield)
 "gkl" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -2676,13 +2839,18 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors)
 "gkU" = (
-/obj/structure/roguewindow,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+/turf/closed/wall/mineral/rogue/wooddark,
+/area/rogue/indoors/town/tavern)
 "glk" = (
 /obj/item/natural/rock,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave)
+"gmN" = (
+/obj/structure/flora/newbranch{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town/tavern)
 "gog" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/dirt/road,
@@ -2762,27 +2930,32 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town/tavern)
 "gDs" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/obj/structure/fluff/railing/fence,
+/turf/open/floor/rogue/tile/bath,
+/area/rogue/indoors/town/bath)
 "gEm" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/outdoors/rtfield)
+"gEI" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/outdoors/mountains)
 "gFz" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/tile/bath,
+/area/rogue/indoors/town/bath)
 "gFA" = (
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/outdoors/rtfield)
 "gFS" = (
 /obj/structure/table/church/m,
-/obj/item/rogueweapon/huntingknife/chefknife,
+/obj/item/rogueweapon/huntingknife/chefknife{
+	pixel_y = 6;
+	pixel_x = -10
+	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
 "gLg" = (
@@ -2815,9 +2988,19 @@
 /area/rogue/indoors/town/tavern)
 "gTx" = (
 /obj/machinery/light/rogue/oven/east,
-/obj/structure/fluff/millstone,
+/obj/structure/fluff/millstone{
+	pixel_y = 10
+	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
+"gVn" = (
+/obj/structure/fluff/walldeco/innsign{
+	pixel_x = 32;
+	name = "The Dark Oak";
+	desc = "The inn of the Frozen Summit outpost. Where tales come to begin and die."
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/mountains)
 "gVB" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/structure/fluff/railing/wood{
@@ -2839,6 +3022,10 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors)
+"gWV" = (
+/obj/structure/mineral_door/wood/window,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/tavern)
 "gYF" = (
 /obj/structure/bed/rogue/inn/hay,
 /obj/machinery/light/rogue/wallfire/candle/r,
@@ -2846,9 +3033,8 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "haj" = (
-/obj/structure/mineral_door/swing_door,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/turf/closed/wall/mineral/rogue/stonebrick,
+/area/rogue/indoors/town/tavern)
 "haP" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
@@ -2857,7 +3043,7 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town/tavern)
 "hdL" = (
-/obj/structure/closet/crate/chest/neu_fancy,
+/obj/structure/rack/rogue/shelf/biggest,
 /obj/item/reagent_containers/glass/cup/wooden,
 /obj/item/reagent_containers/glass/cup/wooden,
 /obj/item/reagent_containers/glass/cup/wooden,
@@ -2868,10 +3054,12 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /obj/item/reagent_containers/glass/cup/wooden,
 /obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
+"heg" = (
+/obj/structure/fermenting_barrel,
+/turf/open/floor/rogue/ruinedwood/turned,
+/area/rogue/indoors/town/tavern)
 "heZ" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/swamp,
@@ -2883,13 +3071,28 @@
 /obj/item/kitchen/rollingpin,
 /turf/open/floor/rogue/twig/platform,
 /area/rogue/indoors)
+"hgl" = (
+/obj/structure/table/wood{
+	icon_state = "longtable";
+	dir = 1
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
+"hgT" = (
+/obj/machinery/light/rogue/wallfire{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/tavern)
 "hiA" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave)
 "hjt" = (
 /obj/machinery/light/rogue/hearth,
-/obj/item/cooking/pan,
+/obj/item/cooking/pan{
+	pixel_y = 28
+	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/rtfield)
 "hlu" = (
@@ -2950,8 +3153,9 @@
 /area/rogue/outdoors/rtfield)
 "hsN" = (
 /obj/structure/fluff/railing/fence,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/rtfield)
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/tile/bath,
+/area/rogue/indoors/town/bath)
 "huD" = (
 /obj/structure/roguewindow/openclose{
 	dir = 1
@@ -2963,7 +3167,9 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/rtfield)
 "hvn" = (
-/obj/structure/fluff/millstone,
+/obj/structure/fluff/millstone{
+	pixel_y = 10
+	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
 "hvE" = (
@@ -3108,13 +3314,16 @@
 /obj/item/rogueweapon/shovel,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
+"ieV" = (
+/obj/structure/fluff/railing/fence,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/tile/bath,
+/area/rogue/indoors/town/bath)
 "ifS" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_y = -1
-	},
+/obj/structure/fluff/railing/border,
+/obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grasscold,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town/tavern)
 "igr" = (
 /obj/structure/fluff/railing/wood,
 /obj/structure/fluff/railing/wood{
@@ -3174,6 +3383,12 @@
 	},
 /turf/open/floor/rogue/snow,
 /area/rogue/outdoors/rtfield)
+"izk" = (
+/obj/structure/flora/newbranch{
+	dir = 1
+	},
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town/tavern)
 "izp" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/roguegrass,
@@ -3188,10 +3403,10 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
 "iCx" = (
-/obj/structure/closet/crate/chest/neu_fancy,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/carpet,
-/area/rogue/outdoors/mountains)
+/obj/structure/bed/rogue/inn/double,
+/obj/item/bedsheet/rogue/double_pelt,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "iDt" = (
 /obj/structure/closet/crate/roguecloset/inn,
 /obj/item/clothing/suit/roguetown/armor/gambeson/hierophant{
@@ -3218,6 +3433,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"iFL" = (
+/obj/structure/roguewindow/openclose/reinforced,
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/town/tavern)
 "iFR" = (
 /obj/structure/roguerock,
 /turf/open/floor/rogue/snow,
@@ -3271,6 +3490,10 @@
 /obj/structure/flora/roguegrass/thorn_bush,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
+"iNJ" = (
+/obj/structure/chair/bench/coucha,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/tavern)
 "iNO" = (
 /obj/structure/mineral_door/wood{
 	lockid = "house6"
@@ -3331,13 +3554,21 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/rtfield)
-"iXp" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 4
+"iWI" = (
+/obj/structure/fluff/railing/border{
+	icon_state = "border";
+	dir = 8
 	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/carpet,
-/area/rogue/outdoors/mountains)
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town/tavern)
+"iXp" = (
+/obj/structure/bed/rogue/inn,
+/obj/item/bedsheet/rogue/pelt,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "iXB" = (
 /obj/machinery/light/rogue/torchholder{
 	icon_state = "torchwall1";
@@ -3382,6 +3613,17 @@
 /obj/structure/roguetent,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
+"jem" = (
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	pixel_y = 6
+	},
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/toy/cards/deck,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/tavern)
 "jfy" = (
 /obj/structure/stairs{
 	icon_state = "stairs";
@@ -3389,6 +3631,9 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/rtfield)
+"jgr" = (
+/turf/closed/wall/mineral/rogue/wooddark/horizontal,
+/area/rogue/indoors/town/tavern)
 "jgZ" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/outdoors/rtfield)
@@ -3432,12 +3677,11 @@
 /area/rogue/outdoors/rtfield)
 "jvD" = (
 /obj/machinery/light/rogue/oven/east,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/tavern)
 "jwt" = (
-/obj/machinery/light/rogue/wallfire,
-/turf/closed/wall/mineral/rogue/stonebrick,
-/area/rogue/outdoors/mountains)
+/turf/closed/wall/mineral/rogue/wooddark/vertical,
+/area/rogue/indoors/town/tavern)
 "jwv" = (
 /obj/structure/fermenting_barrel/hagwoodbitter,
 /turf/open/floor/rogue/cobble,
@@ -3472,11 +3716,8 @@
 	},
 /area/rogue/outdoors/rtfield)
 "jBC" = (
-/obj/structure/bed/rogue/inn/wool,
-/obj/item/bedsheet/rogue/wool,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/twig/platform,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/tile/bath,
+/area/rogue/indoors/town/bath)
 "jBO" = (
 /obj/structure/flora/roguegrass/pyroclasticflowers,
 /turf/open/floor/rogue/grasscold,
@@ -3502,6 +3743,10 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
+"jEX" = (
+/obj/structure/closet/crate/roguecloset/inn/south,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/tavern)
 "jFM" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -3570,9 +3815,9 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town)
 "jRN" = (
-/obj/structure/mineral_door/wood/donjon/stone,
-/turf/open/floor/rogue/carpet,
-/area/rogue/outdoors/mountains)
+/obj/structure/ladder/unbreakable,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "jSD" = (
 /obj/structure/closet/crate/chest/wicker,
 /obj/machinery/light/rogue/torchholder{
@@ -3676,9 +3921,11 @@
 /turf/open/floor/rogue/twig/platform,
 /area/rogue/indoors)
 "kjj" = (
-/obj/structure/fluff/walldeco/innsign,
-/turf/closed/wall/mineral/rogue/stonebrick,
-/area/rogue/outdoors/mountains)
+/obj/structure/roguewindow/openclose/reinforced{
+	dir = 4
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/town/tavern)
 "kjK" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf,
 /turf/open/floor/rogue/snow{
@@ -3690,10 +3937,11 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
 "klJ" = (
-/obj/structure/chair/stool/rogue,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+/obj/structure/table/wood{
+	icon_state = "longtable"
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "kmJ" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
@@ -3735,6 +3983,16 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/rtfield)
+"kyi" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	icon_state = "border";
+	dir = 5
+	},
+/turf/open/floor/rogue/grasscold,
+/area/rogue/indoors/town/tavern)
 "kzb" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/hexstone,
@@ -3797,18 +4055,12 @@
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/rtfield)
 "kFF" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
 	},
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 8
-	},
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/obj/item/mundane/puzzlebox/easy,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/tavern)
 "kFM" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -3832,7 +4084,9 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
 "kFW" = (
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = 24
+	},
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 4
 	},
@@ -3843,6 +4097,10 @@
 /obj/structure/spacevine,
 /turf/open/water/swamp,
 /area/rogue/under/cave)
+"kHq" = (
+/obj/structure/stairs,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/tavern)
 "kIk" = (
 /obj/structure/stairs{
 	icon_state = "stairs";
@@ -3881,7 +4139,9 @@
 /area/rogue/indoors)
 "kLI" = (
 /obj/structure/fluff/railing/border{
-	dir = 9
+	dir = 9;
+	pixel_y = -26;
+	pixel_x = -6
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
@@ -3961,6 +4221,13 @@
 /obj/effect/landmark/start/orphan,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
+"kUE" = (
+/obj/structure/table/wood{
+	icon_state = "longtable";
+	dir = 8
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "kUM" = (
 /obj/structure/stairs{
 	icon_state = "stairs";
@@ -4038,16 +4305,15 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/outdoors/mountains)
 "lhz" = (
-/obj/structure/flora/newbranch{
+/obj/structure/flora/newbranch/leafless{
 	dir = 8
 	},
-/obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/grasscold,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town/tavern)
 "ljR" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/closed/wall/mineral/rogue/stonebrick,
-/area/rogue/outdoors/mountains)
+/obj/structure/mineral_door/wood/deadbolt/shutter,
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/town/tavern)
 "lkN" = (
 /obj/structure/bed/rogue/inn/double,
 /obj/item/bedsheet/rogue/double_pelt,
@@ -4121,6 +4387,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach)
+"luX" = (
+/obj/structure/fluff/wallclock/l,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/tavern)
 "lvL" = (
 /obj/machinery/light/rogue/torchholder/l,
 /obj/structure/fluff/railing/wood{
@@ -4132,7 +4402,8 @@
 	},
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
-	dir = 4
+	dir = 4;
+	pixel_x = 6
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/rtfield)
@@ -4203,6 +4474,16 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/ruinedwood/platform,
 /area/rogue/outdoors/mountains)
+"lHL" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/soap/herbal,
+/obj/item/soap/herbal,
+/obj/item/soap/herbal,
+/obj/item/soap/herbal,
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/town/bath)
 "lHP" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 1
@@ -4288,10 +4569,14 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
+"maM" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/tavern)
 "maY" = (
-/obj/structure/fluff/walldeco/innsign,
-/turf/closed/wall/mineral/rogue/decowood,
-/area/rogue/outdoors/rtfield)
+/obj/structure/roguewindow,
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/town/tavern)
 "mcz" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/transparent/openspace,
@@ -4326,9 +4611,14 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
 "mke" = (
-/obj/structure/roguewindow,
-/turf/closed,
-/area/rogue/outdoors/rtfield)
+/turf/closed/wall/mineral/rogue/decowood,
+/area/rogue/indoors/town/tavern)
+"mkF" = (
+/obj/structure/fluff/railing/border{
+	pixel_y = -6
+	},
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/outdoors/mountains)
 "mlT" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
@@ -4344,9 +4634,14 @@
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
 	},
-/obj/item/cooking/pan,
+/obj/item/cooking/pan{
+	pixel_y = 28
+	},
 /obj/item/kitchen/rollingpin,
-/obj/item/rogueweapon/huntingknife/chefknife,
+/obj/item/rogueweapon/huntingknife/chefknife{
+	pixel_y = 6;
+	pixel_x = -10
+	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
 "mtb" = (
@@ -4398,6 +4693,10 @@
 	icon_state = "chess"
 	},
 /area/rogue/indoors/town/vault)
+"mzJ" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/tavern)
 "mzO" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -4470,6 +4769,10 @@
 	},
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors)
+"mLx" = (
+/obj/structure/chair/bench/coucha/r,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/tavern)
 "mLS" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/naturalstone,
@@ -4545,6 +4848,19 @@
 	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/outdoors/rtfield)
+"mXN" = (
+/obj/structure/fluff/railing/border{
+	icon_state = "border";
+	dir = 8;
+	pixel_x = -6
+	},
+/obj/structure/chair/wood/rogue/chair3,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/outdoors/mountains)
+"ndE" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/indoors/town/tavern)
 "neh" = (
 /obj/machinery/light/rogue/campfire,
 /turf/open/floor/rogue/dirt/road,
@@ -4559,6 +4875,25 @@
 	dir = 4
 	},
 /area/rogue/outdoors/beach)
+"nfz" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	icon_state = "border";
+	dir = 9
+	},
+/obj/structure/fluff/railing/border{
+	icon_state = "border";
+	dir = 8;
+	pixel_x = -6
+	},
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/outdoors/mountains)
+"ngd" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/tile/bath,
+/area/rogue/indoors/town/bath)
 "ngx" = (
 /obj/structure/stairs/stone{
 	dir = 8
@@ -4581,8 +4916,7 @@
 /area/rogue/outdoors/beach)
 "niO" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	icon_state = "longtable_mid"
 	},
 /obj/item/clothing/neck/roguetown/psicross/eora,
 /obj/machinery/light/rogue/wallfire{
@@ -4630,6 +4964,31 @@
 /obj/effect/landmark/start/vagrant,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
+"nvM" = (
+/obj/machinery/light/rogue/wallfire{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
+"nwg" = (
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/kitchen/spoon,
+/obj/item/kitchen/spoon,
+/obj/item/kitchen/spoon,
+/obj/item/kitchen/spoon,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/kitchen/fork,
+/obj/item/kitchen/fork,
+/obj/item/kitchen/fork,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "nww" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -4644,6 +5003,12 @@
 /obj/structure/fluff/railing/border,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/beach)
+"nwP" = (
+/obj/structure/closet/crate/chest/neu,
+/obj/item/book/rogue/cooking,
+/obj/item/reagent_containers/glass/bottle/waterskin/milk,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town/tavern)
 "nym" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
@@ -4749,14 +5114,20 @@
 	dir = 4
 	},
 /area/rogue/outdoors/rtfield)
+"ocm" = (
+/obj/structure/flora/newbranch/connector{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town/tavern)
 "odi" = (
 /obj/structure/far_travel,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
 "odW" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/carpet,
-/area/rogue/outdoors/mountains)
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/tavern)
 "ogi" = (
 /turf/open/water/ocean{
 	name = "river water";
@@ -4820,6 +5191,16 @@
 /obj/item/alch/silverdust,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/rtfield)
+"ooQ" = (
+/obj/structure/closet/crate/chest/neu,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/food/snacks/fat,
+/obj/item/reagent_containers/food/snacks/fat,
+/obj/item/reagent_containers/food/snacks/fat,
+/obj/item/reagent_containers/food/snacks/fat,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town/tavern)
 "opX" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -4827,11 +5208,8 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors)
 "osM" = (
-/obj/structure/bed/rogue/inn/wool,
-/obj/item/bedsheet/rogue/wool,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/twig/platform,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/tavern)
 "otl" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_y = 32
@@ -4846,9 +5224,17 @@
 /area/rogue/outdoors/mountains)
 "oyy" = (
 /obj/structure/fluff/railing/border,
-/obj/structure/fermenting_barrel/blackgoat,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/obj/structure/table/wood{
+	icon_state = "longtable";
+	dir = 1
+	},
+/obj/item/rogueweapon/huntingknife/chefknife{
+	pixel_y = 6;
+	pixel_x = -10
+	},
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "oAx" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/ruinedwood,
@@ -4921,6 +5307,12 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"oLH" = (
+/obj/structure/flora/newbranch{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town/tavern)
 "oLW" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors)
@@ -4956,6 +5348,21 @@
 	color = "e6f2ff"
 	},
 /area/rogue/outdoors/rtfield)
+"oQO" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/outdoors/mountains)
 "oSE" = (
 /obj/structure/spacevine,
 /turf/open/floor/rogue/dirt,
@@ -5030,12 +5437,16 @@
 	},
 /area/rogue/outdoors/rtfield)
 "pcR" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/obj/structure/stairs{
+	icon_state = "stairs";
+	dir = 4
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "pdz" = (
-/turf/open/floor/rogue/twig/platform,
-/area/rogue/outdoors/mountains)
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/tavern)
 "pdC" = (
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/mountains)
@@ -5109,10 +5520,9 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors)
 "pof" = (
-/obj/structure/bed/rogue/inn/double,
-/obj/item/bedsheet/rogue/fabric_double,
-/turf/open/floor/rogue/carpet,
-/area/rogue/outdoors/mountains)
+/obj/structure/closet/crate/roguecloset/inn/south,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "poA" = (
 /obj/structure/spacevine,
 /obj/structure/flora/roguegrass/water,
@@ -5130,7 +5540,9 @@
 /turf/open/floor/rogue/snow,
 /area/rogue/outdoors/rtfield)
 "pqB" = (
-/obj/structure/fluff/millstone,
+/obj/structure/fluff/millstone{
+	pixel_y = 10
+	},
 /obj/machinery/light/rogue/oven/south,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/rtfield)
@@ -5235,13 +5647,19 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
 "pDl" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	pixel_y = 6
+	},
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/tavern)
 "pFB" = (
-/obj/structure/flora/newbranch,
+/obj/structure/fluff/railing/border,
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = 24
+	},
 /turf/open/floor/rogue/grasscold,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town/tavern)
 "pGZ" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/structure/fluff/railing/border{
@@ -5287,13 +5705,33 @@
 "pLn" = (
 /obj/structure/mineral_door/swing_door,
 /turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town/tavern)
 "pLE" = (
 /obj/structure/rack/rogue,
 /obj/item/natural/cloth,
 /obj/item/natural/cloth,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/rtfield)
+"pLQ" = (
+/obj/structure/rack/rogue/shelf/big,
+/obj/item/reagent_containers/glass/cup/steel{
+	pixel_y = 20;
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/glass/cup/steel{
+	pixel_y = 20;
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/glass/cup/steel{
+	pixel_y = 12;
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/glass/cup/steel{
+	pixel_y = 12;
+	pixel_x = -4
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town/tavern)
 "pNv" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -5354,7 +5792,8 @@
 "pZI" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
-	dir = 4
+	dir = 4;
+	pixel_x = 6
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
@@ -5427,13 +5866,9 @@
 /turf/closed/mineral/random/rogue/high,
 /area/rogue/indoors/town/tavern)
 "qsC" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 8
-	},
-/turf/closed/wall/mineral/rogue/decowood,
-/area/rogue/outdoors/rtfield)
+/obj/structure/chair/wood/rogue,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "quh" = (
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/dirt/road,
@@ -5474,7 +5909,8 @@
 "qzM" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
-	dir = 4
+	dir = 4;
+	pixel_x = 6
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "vertw";
@@ -5488,6 +5924,10 @@
 "qAp" = (
 /obj/structure/fluff/dryingrack,
 /turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/tavern)
+"qBS" = (
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "qBT" = (
 /obj/effect/decal/mossy,
@@ -5586,7 +6026,9 @@
 /area/rogue/under/cave)
 "rak" = (
 /obj/structure/fluff/railing/border{
-	dir = 9
+	dir = 9;
+	pixel_y = -26;
+	pixel_x = -6
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors)
@@ -5644,6 +6086,12 @@
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/floor/rogue/dirt/ambush,
 /area/rogue/under/cave)
+"reG" = (
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/indoors/town/tavern)
 "rhJ" = (
 /obj/structure/closet/crate/chest/wicker{
 	opened = 1
@@ -5720,12 +6168,13 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors)
 "rHC" = (
-/obj/structure/stairs{
-	icon_state = "stairs";
+/obj/structure/fermenting_barrel/water,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/structure/fluff/railing/border{
 	dir = 4
 	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/tavern)
 "rHH" = (
 /obj/structure/closet/crate/roguecloset/inn,
 /obj/item/clothing/shoes/roguetown/boots/clothlinedanklets,
@@ -5739,9 +6188,8 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/tavern)
 "rJa" = (
-/obj/structure/closet/crate/chest/neu_fancy,
-/turf/open/floor/rogue/twig/platform,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/tavern)
 "rJC" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/mountains)
@@ -5827,7 +6275,8 @@
 "rVC" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
-	dir = 4
+	dir = 4;
+	pixel_x = 6
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/beach)
@@ -5837,6 +6286,9 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/rtfield)
+"rXE" = (
+/turf/open/floor/rogue/rooftop/green,
+/area/rogue/outdoors/mountains)
 "rYb" = (
 /obj/structure/mineral_door/wood{
 	name = "house i";
@@ -5896,9 +6348,12 @@
 /turf/open/floor/rogue/churchrough,
 /area/rogue/outdoors/rtfield)
 "shW" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+/obj/structure/fermenting_barrel/zagul,
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/tavern)
 "sif" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/roguegrass,
@@ -5940,12 +6395,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
 "skH" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 10
-	},
-/turf/open/floor/rogue/dirt,
-/area/rogue/under/cave)
+/turf/open/water/bath,
+/area/rogue/indoors/town/bath)
 "slK" = (
 /obj/structure/mineral_door/wood/fancywood{
 	lockid = "house6";
@@ -5994,9 +6445,15 @@
 /turf/closed/mineral/random/rogue/high,
 /area/rogue/outdoors/mountains)
 "ssA" = (
-/obj/structure/table/wood/bar,
-/turf/open/floor/rogue/twig/platform,
-/area/rogue/outdoors/mountains)
+/obj/structure/rack/rogue/shelf,
+/obj/item/cooking/pan{
+	pixel_y = 28
+	},
+/obj/item/rogueweapon/huntingknife/cleaver{
+	pixel_y = 28
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "ssO" = (
 /obj/effect/decal/mossy{
 	dir = 1
@@ -6014,9 +6471,9 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/rtfield)
 "sux" = (
-/obj/structure/mineral_door/wood/fancywood,
+/obj/structure/roguetent,
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town/bath)
 "suB" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -6029,6 +6486,18 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
+"sAQ" = (
+/obj/structure/bed/rogue/inn/double,
+/obj/item/bedsheet/rogue/fabric_double,
+/obj/structure/fluff/walldeco/rpainting/crown{
+	pixel_x = 32
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/tavern)
+"sBx" = (
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grasscold,
+/area/rogue/indoors/town/tavern)
 "sCB" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
@@ -6037,10 +6506,6 @@
 /turf/open/floor/rogue/ruinedwood/platform,
 /area/rogue/outdoors/mountains)
 "sDO" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 10
-	},
 /obj/effect/decal/cobbleedge{
 	dir = 1
 	},
@@ -6063,6 +6528,16 @@
 /obj/structure/table/wood,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/rtfield)
+"sGJ" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/tavern)
+"sHY" = (
+/obj/structure/roguewindow/openclose{
+	dir = 1
+	},
+/turf/open/floor/rogue/twig,
+/area/rogue/indoors/town/tavern)
 "sJC" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -6105,6 +6580,17 @@
 "sPC" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains)
+"sRQ" = (
+/obj/structure/fluff/railing/border{
+	icon_state = "border";
+	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	icon_state = "border";
+	dir = 9
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town/tavern)
 "sRV" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach)
@@ -6169,7 +6655,9 @@
 	icon_state = "tablewood1"
 	},
 /obj/item/kitchen/rollingpin,
-/obj/item/cooking/pan,
+/obj/item/cooking/pan{
+	pixel_y = 28
+	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
 "tbN" = (
@@ -6227,13 +6715,13 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
 "tjx" = (
-/obj/structure/roguewindow,
-/turf/open/floor/rogue/grasscold,
-/area/rogue/outdoors/rtfield)
+/obj/structure/mineral_door/wood/window,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "tjy" = (
 /obj/structure/flora/newtree,
-/turf/open/floor/rogue/twig/platform,
-/area/rogue/outdoors/mountains)
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town/tavern)
 "tjV" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -6321,6 +6809,12 @@
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"tBD" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/outdoors/mountains)
 "tCj" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors/town/tavern)
@@ -6336,6 +6830,13 @@
 /obj/structure/rack/rogue/shelf/biggest,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
+"tIR" = (
+/obj/structure/fluff/railing/border{
+	icon_state = "border";
+	dir = 8
+	},
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town/tavern)
 "tKp" = (
 /turf/open/floor/carpet/royalblack,
 /area/rogue/outdoors/rtfield)
@@ -6348,9 +6849,10 @@
 /area/rogue/indoors/town/tavern)
 "tOE" = (
 /obj/structure/closet/crate/roguecloset/inn/south,
-/obj/item/soap/herbal,
+/obj/item/clothing/suit/roguetown/shirt/tunic/white,
+/obj/item/clothing/suit/roguetown/shirt/tunic/white,
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town/bath)
 "tOR" = (
 /obj/structure/stairs{
 	dir = 8
@@ -6379,13 +6881,15 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave)
 "tTH" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 8
+/obj/structure/fluff/railing/border,
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 6
 	},
 /turf/open/floor/rogue/grasscold,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town/tavern)
 "tVm" = (
 /obj/structure/closet/crate/chest/old_crate,
 /obj/item/rogueweapon/hammer,
@@ -6407,6 +6911,10 @@
 "tXZ" = (
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
+"tYR" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/tavern)
 "ubC" = (
 /turf/open/water/swamp,
 /area/rogue/outdoors/rtfield)
@@ -6468,21 +6976,16 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "uqL" = (
-/obj/structure/closet/crate/roguecloset/inn/south,
-/obj/item/soap/herbal,
-/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town/bath)
 "uqO" = (
 /obj/structure/fluff/railing/stonehedge,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield)
 "uro" = (
-/obj/structure/bed/rogue/inn/wool,
-/obj/item/bedsheet/rogue/wool,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/twig/platform,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town/tavern)
 "urD" = (
 /obj/structure/mineral_door/wood{
 	name = "house ii";
@@ -6542,6 +7045,10 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave)
+"uzE" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/outdoors/mountains)
 "uBR" = (
 /turf/closed/mineral/random/rogue/med,
 /area/rogue/under/cave)
@@ -6560,9 +7067,11 @@
 	},
 /area/rogue/outdoors/rtfield)
 "uIM" = (
-/obj/structure/table/wood/bar,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+/obj/structure/table/wood{
+	icon_state = "longtable_mid"
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "uJj" = (
 /obj/item/seeds/apple,
 /obj/item/seeds/apple,
@@ -6577,7 +7086,9 @@
 	dir = 8
 	},
 /obj/structure/closet/crate/chest/wicker,
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = 24
+	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
 "uJx" = (
@@ -6634,13 +7145,23 @@
 	pixel_x = 8
 	},
 /turf/closed/wall/mineral/rogue/stonebrick,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town/bath)
 "uXC" = (
 /obj/structure/flora/roguetree/snow{
 	icon_state = "tree11"
 	},
 /turf/open/floor/rogue/snow,
 /area/rogue/outdoors/rtfield)
+"uZf" = (
+/obj/structure/ladder/unbreakable,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town/tavern)
+"vby" = (
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = 24
+	},
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town/tavern)
 "vcT" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf,
 /turf/open/floor/rogue/snow,
@@ -6662,6 +7183,9 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
+"vhl" = (
+/turf/open/floor/rogue/rooftop/green/corner1,
+/area/rogue/outdoors/mountains)
 "vir" = (
 /obj/machinery/light/rogue/smelter/great,
 /obj/structure/fluff/railing/wood{
@@ -6712,19 +7236,16 @@
 	},
 /obj/item/reagent_containers/glass/mortar,
 /obj/item/pestle,
-/obj/item/rogueweapon/huntingknife/chefknife,
+/obj/item/rogueweapon/huntingknife/chefknife{
+	pixel_y = 6;
+	pixel_x = -10
+	},
 /obj/item/kitchen/rollingpin,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/rtfield)
 "vqm" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 2;
-	pixel_y = 7
-	},
 /turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town/tavern)
 "vqp" = (
 /obj/item/rogueweapon/hoe/stone,
 /turf/open/floor/rogue/grasscold,
@@ -6753,11 +7274,10 @@
 /turf/open/floor/rogue/dirt/ambush,
 /area/rogue/outdoors/mountains)
 "vuK" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/beach)
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/roguemachine/atm,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/tavern)
 "vwR" = (
 /obj/machinery/light/rogue/torchholder{
 	icon_state = "torchwall1";
@@ -6798,18 +7318,42 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
 "vFx" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town/bath)
 "vFV" = (
 /obj/structure/flora/roguegrass/water,
 /obj/structure/spacevine,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave)
+"vGf" = (
+/obj/structure/closet/crate/chest/neu,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/powder/salt,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/fat,
+/obj/item/reagent_containers/food/snacks/fat,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "vGx" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"vHb" = (
+/obj/structure/fluff/railing/border{
+	pixel_y = -6
+	},
+/obj/structure/fluff/railing/border{
+	icon_state = "border";
+	dir = 4;
+	pixel_x = 6
+	},
+/obj/structure/fluff/dryingrack,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/outdoors/mountains)
 "vIa" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/ruinedwood/platform,
@@ -6841,7 +7385,9 @@
 /obj/item/rogueweapon/hoe{
 	pixel_y = 5
 	},
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_y = 24
+	},
 /obj/structure/fluff/railing/wood{
 	dir = 8;
 	pixel_y = -1
@@ -6873,7 +7419,9 @@
 /area/rogue/outdoors/rtfield)
 "vNx" = (
 /obj/machinery/light/rogue/hearth,
-/obj/item/cooking/pan,
+/obj/item/cooking/pan{
+	pixel_y = 28
+	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
 "vPI" = (
@@ -6914,10 +7462,17 @@
 /obj/item/reagent_containers/glass/bucket/pot/stone,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
+"vUE" = (
+/obj/structure/table/wood{
+	icon_state = "longtable";
+	dir = 4
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "vVR" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/rtfield)
+/obj/structure/fluff/walldeco/maidensigil,
+/turf/open/floor/rogue/tile/bath,
+/area/rogue/indoors/town/bath)
 "vWh" = (
 /obj/structure/boatbell/fluff{
 	desc = ""
@@ -6951,7 +7506,9 @@
 /area/rogue/outdoors/rtfield)
 "waG" = (
 /obj/structure/fluff/railing/border{
-	dir = 9
+	dir = 9;
+	pixel_y = -26;
+	pixel_x = -6
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/rtfield)
@@ -7033,6 +7590,14 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/snow,
 /area/rogue/outdoors/rtfield)
+"wkF" = (
+/obj/structure/fluff/railing/border{
+	icon_state = "border";
+	dir = 4;
+	pixel_x = 6
+	},
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/outdoors/mountains)
 "wkG" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/beach)
@@ -7190,10 +7755,6 @@
 /area/rogue/outdoors/rtfield)
 "wOE" = (
 /obj/structure/stairs,
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 10
-	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
 "wPI" = (
@@ -7212,7 +7773,9 @@
 /area/rogue/outdoors/mountains)
 "wSj" = (
 /obj/structure/fluff/railing/border{
-	dir = 9
+	dir = 9;
+	pixel_y = -26;
+	pixel_x = -6
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach)
@@ -7249,9 +7812,28 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/tavern)
 "wWO" = (
-/obj/structure/fermenting_barrel/zagul,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+/obj/structure/fermenting_barrel/beer,
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	icon_state = "border";
+	dir = 5
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town/tavern)
+"wYc" = (
+/obj/structure/closet/crate/roguecloset/inn,
+/obj/item/clothing/suit/roguetown/shirt/dress,
+/obj/item/clothing/cloak/apron/waist,
+/obj/item/clothing/shoes/roguetown/shortboots,
+/obj/item/clothing/under/roguetown/tights/stockings/white,
+/obj/item/clothing/under/roguetown/tights/stockings/silk/white,
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/indoors/town/tavern)
 "wZe" = (
 /obj/effect/landmark/start/veteran,
 /turf/open/floor/rogue/dirt/road,
@@ -7261,15 +7843,18 @@
 /turf/open/floor/rogue/churchrough,
 /area/rogue/outdoors/rtfield)
 "xbj" = (
-/obj/structure/table/church/m,
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
 /obj/structure/fluff/railing/border,
-/obj/item/cooking/pan,
-/obj/item/rogueweapon/huntingknife/chefknife,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/obj/structure/table/wood{
+	icon_state = "longtable"
+	},
+/obj/structure/fluff/millstone{
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/peppermill{
+	pixel_x = -6
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/tavern)
 "xbr" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -7302,8 +7887,8 @@
 "xfP" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/reagent_containers/glass/bucket/pot,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/tavern)
 "xgy" = (
 /obj/structure/fluff/dryingrack,
 /turf/open/floor/rogue/blocks,
@@ -7318,14 +7903,20 @@
 /obj/structure/closet/crate/roguecloset,
 /obj/item/reagent_containers/glass/cup/wooden,
 /obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/steel,
-/obj/item/reagent_containers/glass/cup/steel,
+/obj/item/reagent_containers/glass/cup/steel{
+	pixel_y = 20;
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/glass/cup/steel{
+	pixel_y = 20;
+	pixel_x = 4
+	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "xki" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "xlq" = (
 /obj/item/natural/rock,
 /turf/open/floor/rogue/dirt/road,
@@ -7438,6 +8029,9 @@
 "xAZ" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/tavern)
+"xBr" = (
+/turf/closed/wall/mineral/rogue/decowood,
+/area/rogue/indoors/town/bath)
 "xBE" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/snow{
@@ -7474,6 +8068,10 @@
 	color = "e6f2ff"
 	},
 /area/rogue/outdoors/rtfield)
+"xEO" = (
+/obj/structure/flora/newtree,
+/turf/open/floor/rogue/grasscold,
+/area/rogue/indoors/town/tavern)
 "xHh" = (
 /obj/machinery/light/rogue/torchholder{
 	icon_state = "torchwall1";
@@ -7489,12 +8087,8 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave)
 "xIP" = (
-/obj/structure/bearpelt{
-	pixel_y = -11;
-	pixel_x = -17
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town/tavern)
 "xLL" = (
 /obj/structure/stairs{
 	icon_state = "stairs";
@@ -7588,12 +8182,28 @@
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/outdoors/rtfield)
+"yfX" = (
+/obj/structure/closet/crate/chest/neu_iron,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/obj/item/reagent_containers/glass/bottle/rogue/whitewine,
+/obj/item/reagent_containers/glass/bottle/rogue/redwine,
+/obj/item/reagent_containers/glass/bottle/rogue/wine/sourwine,
+/obj/item/reagent_containers/glass/bottle/rogue/wine/sourwine,
+/obj/item/reagent_containers/glass/bottle/rogue/wine/sourwine,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town/tavern)
 "ygb" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
 	},
-/obj/item/cooking/pan,
-/obj/item/rogueweapon/huntingknife/chefknife,
+/obj/item/cooking/pan{
+	pixel_y = 28
+	},
+/obj/item/rogueweapon/huntingknife/chefknife{
+	pixel_y = 6;
+	pixel_x = -10
+	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
 "ygP" = (
@@ -7601,8 +8211,13 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/rtfield)
 "ygR" = (
-/turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/mountains)
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	pixel_y = 6
+	},
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/wood/herringbone,
+/area/rogue/indoors/town/tavern)
 "ygT" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/naturalstone,
@@ -40438,7 +41053,7 @@ lnn
 djT
 oAP
 gcK
-kFF
+oAP
 xOC
 xOC
 xOC
@@ -43186,14 +43801,14 @@ iSL
 iSL
 iSL
 iSL
-gDs
+iSL
 teY
 teY
 fLa
 quh
 fsP
 fsP
-fsP
+eOR
 fsP
 fsP
 fsP
@@ -43347,20 +43962,20 @@ fsP
 mVe
 iSL
 rYw
-qYz
-qYz
+haj
+haj
 maY
-gkU
+mke
 pLn
 pLn
-gkU
-cij
-cij
-cij
-cij
-cij
-qYz
-qYz
+mke
+maY
+mke
+mke
+mke
+mke
+haj
+haj
 abe
 fsP
 kzW
@@ -43504,20 +44119,20 @@ abV
 abV
 iSL
 rYw
-qYz
-cij
+haj
+sBx
 cOL
-ehr
-ehr
-ehr
-ehr
+gbf
+vqm
+vqm
+acj
 klJ
-uIM
+xIP
 hdL
 wWO
 shW
 rHC
-qYz
+haj
 fsP
 fsP
 boS
@@ -43661,19 +44276,19 @@ hHC
 abV
 iSL
 aaf
-tjx
-fRr
+maY
+cOL
 lhz
 ifS
-ehr
-ehr
-ehr
+vqm
+vqm
 acj
-uIM
-ehr
-ehr
-ehr
-cij
+hgl
+xIP
+xIP
+xIP
+xIP
+pcR
 mke
 mVe
 fsP
@@ -43818,21 +44433,21 @@ hHC
 cty
 iSL
 iSL
-mke
+maY
 feq
-ilZ
+xEO
 pFB
-ehr
-ehr
-ehr
-ehr
+vqm
+vqm
+vqm
+mke
+vUE
 uIM
 uIM
-uIM
-uIM
-cij
-cij
-mVe
+kUE
+mke
+mke
+gki
 fsP
 fsP
 mVe
@@ -43975,19 +44590,19 @@ hHC
 cty
 iSL
 iSL
-cij
-cij
+maY
+kyi
 aEv
 tTH
-ehr
-ehr
-ehr
-ehr
+vqm
+vqm
+vqm
+tYR
 acj
 acj
 acj
 acj
-ehr
+tYR
 mke
 mVe
 fsP
@@ -44132,20 +44747,20 @@ abV
 abV
 iSL
 iSL
-cij
-qsC
-tTH
+mke
 vqm
-ehr
-ehr
-ehr
-oMB
-ehr
-ehr
-ehr
-oMB
-ehr
-qYz
+vqm
+vqm
+vqm
+vqm
+vqm
+fUp
+vqm
+vqm
+vqm
+vqm
+vqm
+haj
 mVe
 fsP
 fsP
@@ -44289,20 +44904,20 @@ rDz
 abV
 iSL
 iSL
-qYz
-ehr
-ehr
-ehr
-ehr
-ehr
-ehr
-qYz
-qYz
-cij
-cij
-cij
-qYz
-qYz
+mke
+bpP
+fMf
+mke
+vuK
+vqm
+maM
+haj
+haj
+haj
+haj
+haj
+haj
+haj
 mVe
 fsP
 fsP
@@ -44446,18 +45061,18 @@ rDz
 jLM
 vJn
 iSL
-qYz
-qYz
-qYz
-qYz
-cij
+haj
+vqm
+fMf
+mke
+xBr
 cgj
-cij
-qYz
-kUZ
-czi
-czi
-czi
+xBr
+aqr
+ngd
+skH
+skH
+skH
 hsN
 fRr
 mVe
@@ -44603,19 +45218,19 @@ rVf
 abV
 lnn
 xqr
-xqr
-lnn
-xqr
-qYz
+haj
+haj
+haj
+aqr
 uqL
-dcW
+aCU
 vFx
-qYz
+aqr
 vVR
-czi
-czi
-czi
-hsN
+skH
+skH
+skH
+gDs
 mVe
 fsP
 fsP
@@ -44763,16 +45378,16 @@ xqr
 xqr
 xqr
 xqr
-cij
+aqr
 tOE
-dcW
-mDW
+aCU
+vFx
 sux
-kUZ
-czi
-czi
-czi
-hsN
+jBC
+skH
+skH
+skH
+gDs
 mVe
 fsP
 fsP
@@ -44920,16 +45535,16 @@ xqr
 xqr
 xqr
 lnn
-cij
+xBr
 tOE
-dcW
-mDW
+aCU
+vFx
 sux
-kUZ
-czi
-czi
-czi
-hsN
+jBC
+skH
+skH
+skH
+gDs
 fRr
 fsP
 fsP
@@ -45077,16 +45692,16 @@ xqr
 xqr
 xqr
 lnn
-qYz
+aqr
 tOE
-dcW
-mDW
-qYz
+agk
+lHL
+aqr
 vVR
-czi
-czi
-czi
-hsN
+skH
+skH
+skH
+gDs
 fRr
 mVe
 fsP
@@ -45234,16 +45849,16 @@ xqr
 xqr
 lnn
 lnn
-qYz
 aqr
-dcW
 aqr
-qYz
+xBr
+aqr
+aqr
 gFz
-kUZ
-kUZ
-gFz
-hsN
+jBC
+jBC
+jBC
+ieV
 mVe
 fsP
 fsP
@@ -45391,16 +46006,16 @@ xqr
 lnn
 dPV
 dPV
-qYz
-qYz
-cij
-qYz
-qYz
-qYz
+lnn
+lnn
+lnn
+lnn
+aqr
+aqr
 uXf
 uXf
-qYz
-qYz
+aqr
+aqr
 fsP
 fsP
 fsP
@@ -47015,7 +47630,7 @@ nTR
 nTR
 nTR
 bXK
-aCU
+uty
 sRV
 sRV
 tcr
@@ -47645,7 +48260,7 @@ xOC
 iXP
 sRV
 sRV
-vuK
+sRV
 cKj
 hmb
 cKj
@@ -60988,7 +61603,7 @@ tXZ
 tXZ
 tXZ
 dSI
-skH
+xXW
 arK
 eUQ
 rcv
@@ -67528,12 +68143,12 @@ tXZ
 bPG
 xDp
 sPC
-sPC
-sPC
-sPC
-sPC
 wiu
 sPC
+sPC
+sPC
+sPC
+gVn
 sPC
 sPC
 sPC
@@ -67683,20 +68298,20 @@ tXZ
 tXZ
 tXZ
 tXZ
-xDp
+haj
 haj
 kjj
-xDp
-xDp
-xDp
-xDp
-xDp
-xDp
-xDp
-xDp
-xDp
-xDp
-xDp
+mke
+mke
+kjj
+fld
+mke
+mke
+mke
+mke
+mke
+haj
+haj
 tXZ
 tXZ
 tXZ
@@ -67840,20 +68455,20 @@ kDi
 kDi
 tXZ
 tXZ
-xDp
-ygR
-ygR
 haj
+fki
+oLH
+fki
 ygR
-ygR
-xki
-ssA
-eQb
+rJa
+rJa
+mzJ
+mke
 xfP
 jvD
 xbj
-bRV
-xDp
+fki
+haj
 tXZ
 tXZ
 tXZ
@@ -67997,20 +68612,20 @@ kDi
 kDi
 tXZ
 tXZ
-xDp
+mke
+fki
+ocm
+fki
+aFy
+odW
+rJa
+rJa
 ljR
-xDp
-xDp
-ygR
-ygR
-xki
-ssA
-ygR
-ygR
-ygR
+xIP
+xIP
 oyy
-sKA
-xDp
+fki
+mke
 tXZ
 tXZ
 tXZ
@@ -68154,20 +68769,20 @@ kDi
 kDi
 tXZ
 tXZ
-xDp
-tXZ
+iFL
+izk
 tjy
-xDp
-ygR
-ygR
-xki
-ssA
-ygR
-ygR
-ygR
-ygR
+vby
+jem
+dhi
+rJa
+rJa
+mke
+nwg
+xIP
+xIP
 pcR
-xDp
+fiq
 tXZ
 tXZ
 tXZ
@@ -68311,20 +68926,20 @@ kDi
 kDi
 tXZ
 tXZ
-xDp
+dXh
 fki
-xDp
-xDp
-ygR
-ygR
-ygR
+gmN
+fki
+aFy
+odW
+rJa
+rJa
+mke
 ssA
-ssA
-ssA
-ssA
-haj
-xDp
-xDp
+xIP
+xIP
+jRN
+mke
 tXZ
 tXZ
 tXZ
@@ -68468,20 +69083,20 @@ kDi
 kDi
 tXZ
 tXZ
-xDp
-ygR
-ygR
-xDp
+iFL
+fki
+fki
+fki
 pDl
-ygR
-ygR
+rJa
+rJa
+rJa
+tjx
+qBS
 xki
-xki
-xki
-xki
-ygR
-xDp
-xDp
+flI
+vGf
+haj
 tXZ
 tXZ
 tXZ
@@ -68625,20 +69240,20 @@ kDi
 kDi
 tXZ
 tXZ
-xDp
-ygR
-ygR
+mke
+fki
+fki
 eGj
-pcR
-ygR
-ygR
-ygR
-ygR
-ygR
-ygR
-pcR
-xDp
-xDp
+rJa
+rJa
+rJa
+rJa
+mke
+mke
+mke
+mke
+haj
+haj
 tXZ
 tXZ
 tXZ
@@ -68782,20 +69397,20 @@ kDi
 kDi
 tXZ
 tXZ
-xDp
-xDp
-xDp
-xDp
-xDp
-eGj
-xDp
-xDp
-xDp
-jRN
-xDp
-xDp
-xDp
-tXZ
+haj
+fki
+fki
+kHq
+sGJ
+rJa
+rJa
+rJa
+eQb
+xIP
+dKI
+xIP
+sHY
+rXE
 tXZ
 tXZ
 tXZ
@@ -68939,20 +69554,20 @@ kDi
 kDi
 tXZ
 tXZ
-tXZ
-tXZ
-tXZ
-xDp
-osM
-pdz
-uro
-xDp
-odW
-acs
+haj
+haj
+mke
+mke
+mke
+mke
+rJa
+rJa
+mke
+buh
 iXp
-xDp
-tXZ
-tXZ
+fkd
+mke
+rXE
 tXZ
 tXZ
 tXZ
@@ -69095,21 +69710,21 @@ kDi
 kDi
 kDi
 tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-xDp
+nfz
+gEI
+gWV
+osM
+luX
+osM
+ftV
 rJa
-pdz
 rJa
-xDp
-acs
-acs
-xCz
-xDp
-tXZ
-tXZ
+mke
+mke
+mke
+mke
+mke
+rXE
 tXZ
 tXZ
 tXZ
@@ -69252,21 +69867,21 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-xDp
+tBD
+avF
+mke
+iNJ
+kFF
+osM
+mke
 pdz
-pdz
-pdz
-jwt
-acs
+rJa
+eQb
 xIP
-akh
-xDp
-tXZ
-tXZ
+qsC
+fkd
+sHY
+rXE
 tXZ
 tXZ
 tXZ
@@ -69409,21 +70024,21 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-xDp
+oQO
+fyl
+mke
+mLx
+osM
+osM
+mke
 rJa
-pdz
 rJa
-xDp
-odW
-acs
-acs
-xDp
-tXZ
-tXZ
+mke
+nvM
+xIP
+xIP
+mke
+rXE
 tXZ
 tXZ
 tXZ
@@ -69568,19 +70183,19 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
-xDp
+mke
+hgT
 osM
-pdz
-jBC
-xDp
-iUi
+osM
+mke
+rJa
+rJa
+mke
 pof
 iCx
-xDp
-xDp
-tXZ
+xIP
+haj
+rXE
 tXZ
 tXZ
 tXZ
@@ -69725,19 +70340,19 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
-xDp
-xDp
-xDp
-xDp
-xDp
-xDp
-xDp
-xDp
-xDp
-xDp
-tXZ
+mke
+jEX
+sAQ
+osM
+mke
+mke
+mke
+mke
+mke
+mke
+haj
+haj
+vhl
 tXZ
 tXZ
 tXZ
@@ -69882,11 +70497,11 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
+mke
+mke
+mke
+mke
+mke
 tXZ
 tXZ
 tXZ
@@ -70833,7 +71448,7 @@ tXZ
 tXZ
 aat
 hHC
-fkd
+hHC
 hJj
 hJj
 aat
@@ -91871,11 +92486,11 @@ kDi
 kDi
 kDi
 kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+gkU
+jgr
+gkU
+jgr
+gkU
 tXZ
 tXZ
 tXZ
@@ -92028,11 +92643,11 @@ kDi
 kDi
 kDi
 kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+gkU
+cth
+dLI
+heg
+gkU
 tXZ
 tXZ
 tXZ
@@ -92185,11 +92800,11 @@ kDi
 kDi
 kDi
 kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+gkU
+sRQ
+tIR
+iWI
+gkU
 tXZ
 tXZ
 tXZ
@@ -92342,11 +92957,11 @@ kDi
 kDi
 kDi
 kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+jwt
+eXQ
+uro
+ooQ
+jwt
 tXZ
 tXZ
 tXZ
@@ -92499,11 +93114,11 @@ kDi
 kDi
 kDi
 kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+gkU
+pLQ
+uro
+nwP
+gkU
 tXZ
 tXZ
 tXZ
@@ -92656,11 +93271,11 @@ kDi
 kDi
 kDi
 kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+gkU
+yfX
+uro
+uZf
+gkU
 tXZ
 tXZ
 tXZ
@@ -92813,13 +93428,13 @@ kDi
 kDi
 kDi
 kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-tXZ
-tXZ
+gkU
+jgr
+reG
+jgr
+gkU
+mXN
+eTO
 tXZ
 tXZ
 tXZ
@@ -92969,14 +93584,14 @@ kDi
 kDi
 kDi
 kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-tXZ
-tXZ
+gkU
+gkU
+ndE
+smO
+smO
+gkU
+avF
+mkF
 tXZ
 tXZ
 tXZ
@@ -93126,14 +93741,14 @@ kDi
 kDi
 kDi
 kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-tXZ
-tXZ
-tXZ
+jwt
+wYc
+smO
+smO
+smO
+jwt
+uzE
+mkF
 tXZ
 tXZ
 tXZ
@@ -93275,9 +93890,6 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
-tXZ
 kDi
 kDi
 kDi
@@ -93286,11 +93898,14 @@ kDi
 kDi
 kDi
 kDi
-kDi
-kDi
-tXZ
-tXZ
-tXZ
+gkU
+gkU
+bRV
+doe
+smO
+gWV
+wkF
+vHb
 tXZ
 tXZ
 tXZ
@@ -93431,10 +94046,6 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
-tXZ
-tXZ
 kDi
 kDi
 kDi
@@ -93445,7 +94056,11 @@ kDi
 kDi
 kDi
 kDi
-tXZ
+gkU
+jgr
+gkU
+jgr
+gkU
 tXZ
 tXZ
 tXZ
@@ -93588,10 +94203,6 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
-tXZ
-tXZ
 kDi
 kDi
 kDi
@@ -93602,7 +94213,11 @@ kDi
 kDi
 kDi
 kDi
-tXZ
+kDi
+kDi
+kDi
+kDi
+kDi
 tXZ
 tXZ
 tXZ
@@ -93745,10 +94360,6 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
-tXZ
-tXZ
 kDi
 kDi
 kDi
@@ -93759,7 +94370,11 @@ kDi
 kDi
 kDi
 kDi
-tXZ
+kDi
+kDi
+kDi
+kDi
+kDi
 tXZ
 tXZ
 tXZ
@@ -93904,8 +94519,6 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
 kDi
 kDi
 kDi
@@ -93916,7 +94529,9 @@ kDi
 kDi
 kDi
 kDi
-tXZ
+kDi
+kDi
+kDi
 tXZ
 tXZ
 tXZ
@@ -94061,8 +94676,6 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
 kDi
 kDi
 kDi
@@ -94073,7 +94686,9 @@ kDi
 kDi
 kDi
 kDi
-tXZ
+kDi
+kDi
+kDi
 tXZ
 tXZ
 tXZ
@@ -94218,11 +94833,11 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
+kDi
+kDi
+kDi
+kDi
+kDi
 tXZ
 tXZ
 tXZ


### PR DESCRIPTION
## About The Pull Request

Butters up the central tavern to have the aesthetic originally invisioned for it to have.

The tavern consists of three floors:

**1. Base floor:** Bar area, pretty tree, three barrels (beer, lager, water), and a designated semi-outdoor bath with a changing room for guests. Has an entrance from the outside.
**2. Second floor:** Small dining area, overlooks the pretty tree with it's pretty leaves, prim kitchen, one small room, one medium room, one deluxe room (with balcony). Has an entrance from the outside, and a ladder inside the kitchen to reach the third floor.
**3. Third floor:** Small storage area for more specialized drinks, including wine, cleaning tools, and a leatherskin of milk. Has a room for the barkeep to sleep in (with a balcony to smoke at).


Updated it three times fixing little bugs here and there.
Pictures of the changes (before bug removal) can be found in the mapping channel on the discord.

## Why It's Good For The Game

Makes the pretty tavern even prettier 😊
