### PR TITLE
Adds Abyssal Language to Humens With Kazengun Skin Color

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/roguetown/human/humen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/human/humen.dm
@@ -109,6 +109,8 @@
 /datum/species/human/northern/proc/languages(mob/living/carbon/human/foreign)
 	if(foreign.skin_tone == SKIN_COLOR_GRENZELHOFT)
 		foreign.grant_language(/datum/language/grenzelhoftian)
+	else if(foreign.skin_tone == SKIN_COLOR_KAZENGUN)
+		foreign.grant_language(/datum/language/abyssal)
 
 /datum/species/human/northern/get_skin_list()
 	return list(


### PR DESCRIPTION

## About The Pull Request

Two lines of code change, based off of Grenzelhoftians being able to speak Grenzelhoft.
Makes it so Kanzegun people speak their native language!

## Why It's Good For The Game

Allows people who choose the Kazengun origin for humens to speak their race's language, much akin to how the fantasy germans speak fantasy german.
