### PR TITLE
Fixing Yokai Facesplitting and Skintone

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/roguetown/abyssariad/changeling.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/abyssariad/changeling.dm
@@ -29,8 +29,6 @@
 		TRAIT_LONGSTRIDER,
 	)
 
-	skin_tone_wording = "Championage Branch"
-
 	species_traits = list(
 		MUTCOLORS,
 		EYECOLOR,
@@ -39,7 +37,6 @@
 	)
 
 	default_features = MANDATORY_FEATURE_LIST
-	use_skintones = 1
 	possible_ages = ALL_AGES_LIST //Abyssariads are Immortal. However, if they become stray from Abyssor - they suffer severe dementia, and after some decades, become Dais.
 	skinned_type = /obj/item/stack/sheet/animalhide/human
 	disliked_food = NONE
@@ -169,21 +166,6 @@
 
 /datum/species/abyssariad/changeling/check_roundstart_eligible()
 	return TRUE
-
-
-/datum/species/abyssariad/changeling/get_skin_list()
-	return sortList(list(
-		"Oathbound Muqian" = SKIN_COLOR_OATHBOUND_MUQIAN,
-		"Oathbound Kaizoku" = SKIN_COLOR_OATHBOUND_KAIZOKU,
-		"Oathbound Shuhen" = SKIN_COLOR_OATHBOUND_SHUHEN,
-		"Oathbound Linyou" = SKIN_COLOR_OATHBOUND_LINYOU,
-		"Oathbound Dustwalker" = SKIN_COLOR_OATHBOUND_DUSTWALKER,
-		"Warpcaster Muqian" = SKIN_COLOR_WARPCASTER_MUQIAN,
-		"Warpcaster Kaizoku" = SKIN_COLOR_WARPCASTER_KAIZOKU,
-		"Warpcaster Shuhen" = SKIN_COLOR_WARPCASTER_SHUHEN,
-		"Warpcaster Linyou" = SKIN_COLOR_WARPCASTER_LINYOU,
-		"Warpcaster Dustwalker" = SKIN_COLOR_WARPCASTER_DUSTWALKER,
-	))
 
 /datum/species/abyssariad/changeling/get_hairc_list()
 	return sortList(list(

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -501,7 +501,7 @@
 				mmb_intent = null
 				if(ishuman(src))
 					var/mob/living/carbon/human/K = src
-					if(K.dna.species.name == "Changeling")
+					if(K.dna.species.name == "Yokai")
 						//K.mawchange = FALSE
 						//K.overlay_eldritchjaw = 1  // disactivates jaw -  overlays are BAD for that. Don't use it.
 						//emote.wag_mouth = FALSE //I can't make a wag system.
@@ -511,7 +511,7 @@
 				mmb_intent = new INTENT_BITE(src)
 				if(ishuman(src))
 					var/mob/living/carbon/human/K = src
-					if(K.dna.species.name == "Changeling")
+					if(K.dna.species.name == "Yokai")
 						//K.mawchange = TRUE
 						//K.overlay_eldritchjaw = 0  // activates jaw -  overlays are BAD for that. Don't use it.
 						//emote.wag_mouth = TRUE //I can't make a wag system.

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -246,8 +246,8 @@
 	name = "wild tongue"
 
 /obj/item/organ/tongue/kitsune
-	name = "changeling tongue"
-	desc = "The tongue that inwardly bends the moldable changeling skull into a glasgow smile, or other shapes depending on their branch."
+	name = "yokai tongue"
+	desc = "The tongue that inwardly bends the moldable yokai skull into a glasgow smile, or other shapes depending on their branch."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "eldritch"
 	slot = ORGAN_SLOT_TONGUE

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -141,6 +141,7 @@ h1.alert, h2.alert	{color: #c9c1ba;font-family: Pterra, TrueType;}
 .reptile				{font-family: "Kingthings Petrock", Pterra; font-size: 120%;}
 .lupian					{font-family: "Emperialisme", Pterra; font-size: 120%;}
 .felid					{font-family: "Rasyideen", Pterra; font-size: 120%;}
+.abyssal				{font-family: "Henshin", Pterra;}
 
 .torture				{color: #42ff20}
 


### PR DESCRIPTION

## About The Pull Request

Makes it so we get that neat little facesplitting to work for Yokai again. Issue was changing their name, but that is now fixed! Still waiting for the overlay to get fixed tho
![image](https://github.com/user-attachments/assets/cf4f7648-a991-40c0-b6e6-b5c805190d9e)

Also, removed the unused lines of code for skin tone, knowing that Yokai can freely select their skin color now.
_...and i'm still trying to get the font for abyssal to work correctly_

## Why It's Good For The Game

Fixing intended game mechanics, my beloved 😊
