### PR TITLE
Removing Yokai Accent Lock

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/roguetown/abyssariad/_abyssariad.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/abyssariad/_abyssariad.dm
@@ -14,8 +14,6 @@
 	C.grant_language(/datum/language/abyssal)
 	C.cmode_music = list('sound/music/kaizoku/combat/combat_changeling.ogg','sound/music/kaizoku/combat/combat_stormwarrior.ogg','sound/music/kaizoku/combat/combat_searaider.ogg','sound/music/kaizoku/combat/combat_oldtides.ogg','sound/music/kaizoku/combat/combat_decapitator.ogg','sound/music/kaizoku/combat/combat_emperor.ogg','sound/music/kaizoku/combat/combat_traditional.ogg','sound/music/kaizoku/combat/combat_navalretainers.ogg','sound/music/kaizoku/combat/combat_kyudo.ogg')
 
-/datum/species/abyssariad/get_accent(mob/living/carbon/human/H)
-	return strings("abyssal_replacement.json", "abyssal")
 
 ///mob/proc/banzai() //Don't have female 'Banzai' yells for that.
 //	set name = "Banzai"

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/roguetown_species.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/roguetown_species.dm
@@ -35,6 +35,8 @@
 			return strings("feline_replacement.json", type)
 		if("Slopes accent")
 			return strings("welsh_replacement.json", type)
+		if("Kara-Tur accent")
+			return strings("abyssal_replacement.json", type)
 
 /datum/species/proc/get_accent(mob/living/carbon/human/H)
 	return get_accent_list(H,"full")

--- a/modular_hearthstone/code/datums/accents.dm
+++ b/modular_hearthstone/code/datums/accents.dm
@@ -13,7 +13,8 @@ GLOBAL_LIST_INIT(character_accents, list("No accent",
 	"Hissy accent",
 	"Inzectoid accent",
 	"Feline accent",
-	"Slopes accent"))
+	"Slopes accent",
+	"Kara-Tur accent"))
 
 /mob/living/carbon/human
 	var/char_accent = "No accent"

--- a/strings/abyssal_replacement.json
+++ b/strings/abyssal_replacement.json
@@ -1,6 +1,5 @@
 {
-
-    "abyssal": {
+    "full": {
         "what?": "nani?",
         "'s ": "-no ",
         " evil": "aku",
@@ -97,20 +96,18 @@
         "sociopath": "menhera",
         "fragger": "menhera",
         "poem": "haiku",
-        "cyborg": "abyssal automata",
-        "robot": "abyssal automata",
-        "automation": "abyssal automata",
-        "golem": "abyssal automata",
-        "animatronic": "abyssal automata",
-        "mecha": "abyssal automata",
-        "droid": "abyssal automata",
-        "bot ": "abyssal automata",
-        "bionic": "abyssal automata",
+        "cyborg": "automata",
+        "robot": "automata",
+        "animatronic": "automata",
+        "mecha": "automata",
+        "droid": "automata",
+        "bot ": "automata",
+        "bionic": "automata",
         "psydon": "weeper",
         "jesus": "kami",
         "christ": "kami",
-        "the earth": "abyssor's spine",
-        "werewolf": "dendorblight",
+        "the earth": "Mielikki's spine",
+        "werewolf": "blightspawn",
         "opium": "ozium",
         "cocaine": "moondust",
         "magic": "qigong",
@@ -121,23 +118,13 @@
         "vibing": "deraging",
         "freak": "deviant",
         "weirdo": "misfit",
-        "yokai": "abyssariad ",
-        "youkai": "abyssariad ",
-        "ayakashi": "abyssariad ",
-        "mononoke": "abyssariad ",
-        "mamono": "abyssariad ",
-        "abyssriad": "abyssariad ",
-        "abyssaryad": "abyssariad ",
-        "abissariad": "abyssariad ",
-        "japanese": "abyssariad ",
-        "mongol": "abyssariad ",
-        "chinese": "abyssariad ",
-        "tibetian": "abyssariad ",
-        "korean": "abyssariad ",
-        "samurai": "zamurai",
+        "japanese": "yokai ",
+        "mongol": "yokai ",
+        "chinese": "yokai ",
+        "tibetian": "yokai ",
+        "korean": "yokai ",
         "cocksucker": "jawsexer",
         "cocksucking": "jawsexxing",
-        "katana": "zatana",
 
         "dakimakura": "Dishonor. I'm not going to say that.",
         "nyah ": "Dishonor. I'm not going to say that.",
@@ -152,17 +139,26 @@
         "laowai": "whaler",
 
         "desu": "it is",
+		"gozaru": "I daresay",
         "hentai": "pervert",
         "kawaii": "cute",
         "kawai": "cute",
         "idiot": "bakatare",
         "baka": "bakatare",
-        "banzai": "long live the heavenly emperor",
-        "tenno heika": "long live the heavenly emperor",
 
         "changeling": "kitsune",
 		"denmorian": "tengu",
 		"ogrun": "oni",
+		"ogre": "oni",
         "undine": "kappa"
+    },
+	"start": {
+
+    },
+    "end": {
+
+    },
+    "syllable": {
+
     }
 }


### PR DESCRIPTION

## About The Pull Request

Makes it so people who play Yokai aren't locked to the abyssal accent that used to be forced onto them, and also makes it so you can select it for any other character through the accent menu! Aint that neat?

Yokai w/out accent.  (wrote "what what")
![image](https://github.com/user-attachments/assets/b2841603-1604-4dac-8656-c205a563519e)

Human w/Kara-Tur accent.  (wrote "what gozaru")
![image](https://github.com/user-attachments/assets/a60c04ce-1e14-4e65-a6df-a65899222611)


## Why It's Good For The Game

More customization for everyone, also unfuckshits Yokai incase people don't want to drop NANI?! anytime they say "what"
also, awesome 😎😁
