### PR TITLE
The Hamlet Areaning

### DIFF
--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -18,23 +18,23 @@
 "aac" = (
 /obj/effect/landmark/start/alchemist,
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "aad" = (
 /obj/effect/landmark/start/apothecary,
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "aae" = (
 /obj/effect/landmark/start/adventurer,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "aaf" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "aag" = (
 /obj/effect/landmark/start/farmer,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "aah" = (
 /obj/effect/landmark/start/templar,
 /turf/open/floor/rogue/churchmarble,
@@ -53,7 +53,7 @@
 	dir = 8
 	},
 /turf/closed/wall/mineral/rogue/wood,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "aal" = (
 /obj/structure/fluff/walldeco/painting{
 	pixel_y = 32
@@ -68,7 +68,7 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "aan" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/tile{
@@ -96,7 +96,7 @@
 "aaq" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/wood/herringbone,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "aar" = (
 /obj/machinery/light/rogue/torchholder/c{
 	dir = 8
@@ -123,11 +123,11 @@
 	},
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "aav" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "aaw" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8
@@ -135,28 +135,26 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/church)
 "aax" = (
-/obj/structure/roguewindow/openclose{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/obj/structure/stairs,
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town)
 "aay" = (
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "aaz" = (
 /obj/effect/landmark/start/servant,
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "aaA" = (
 /obj/structure/chair/wood/rogue/throne,
 /obj/structure/roguemachine/titan,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "aaB" = (
 /obj/effect/landmark/start/servant,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "aaC" = (
 /obj/effect/landmark/start/cleric,
 /turf/open/floor/rogue/churchrough,
@@ -166,75 +164,70 @@
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "aaE" = (
 /obj/machinery/gear_painter,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "aaF" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "aaG" = (
-/obj/structure/fluff/walldeco/customflag,
-/turf/closed/wall/mineral/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/obj/structure/flora/roguetree/snow{
+	icon_state = "tree6"
+	},
+/turf/open/floor/rogue/snow{
+	color = "e6f2ff"
+	},
+/area/rogue/outdoors/town)
 "aaH" = (
 /obj/effect/landmark/start/merchant,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "aaI" = (
 /obj/effect/landmark/start/butler,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "aaJ" = (
 /obj/effect/landmark/start/lord,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "aaK" = (
 /obj/effect/landmark/start/lady,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "aaL" = (
 /obj/structure/chair/wood/rogue/throne,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "aaM" = (
 /obj/structure/roguemachine/merchantvend,
 /obj/machinery/light/rogue/wallfire/candle/r,
 /obj/structure/table/wood,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"aaN" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
 "aaO" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/town)
 "aaP" = (
 /obj/machinery/light/rogue/torchholder/c{
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "aaQ" = (
 /obj/machinery/light/rogue/torchholder/c{
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "aaR" = (
-/obj/structure/chair/wood/rogue{
-	dir = 1
+/obj/structure/flora/roguetree/snow{
+	icon_state = "tree6"
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/grasscold,
+/area/rogue/outdoors/town)
 "aaS" = (
 /obj/structure/mineral_door/wood{
 	name = "Meeting Hall"
@@ -242,13 +235,13 @@
 /turf/open/floor/rogue/tile{
 	icon_state = "chess"
 	},
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "aaT" = (
 /obj/structure/stairs/d{
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "aaU" = (
 /obj/machinery/light/rogue/torchholder{
 	icon_state = "torchwall1";
@@ -259,7 +252,7 @@
 "aaV" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "aaW" = (
 /obj/machinery/light/rogue/torchholder{
 	icon_state = "torchwall1";
@@ -269,7 +262,7 @@
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "aaX" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -285,7 +278,7 @@
 /obj/item/paper,
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "aaY" = (
 /obj/structure/closet/crate/chest{
 	name = "house keys";
@@ -293,7 +286,7 @@
 	lockid = "steward"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "aaZ" = (
 /obj/structure/closet/crate/chest{
 	locked = 1;
@@ -318,12 +311,12 @@
 /obj/item/roguekey/nightmaiden,
 /obj/item/roguekey/vault,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "aba" = (
 /obj/effect/landmark/start/magician,
 /obj/structure/roguemachine/atm,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "abb" = (
 /obj/structure/flora/bush,
 /turf/open/floor/rogue/snow{
@@ -333,37 +326,37 @@
 "abc" = (
 /obj/effect/landmark/start/mercenary,
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "abd" = (
 /obj/effect/landmark/start/mercenary,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "abe" = (
 /obj/effect/landmark/start/villager,
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "abf" = (
 /obj/effect/landmark/start/villager,
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "abg" = (
 /obj/effect/landmark/start/villager,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "abh" = (
 /obj/effect/landmark/start/steward,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "abi" = (
 /obj/effect/landmark/start/sheriff,
 /obj/structure/roguemachine/withdraw,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "abj" = (
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "abk" = (
 /turf/open/water/pond{
 	name = "hotspring";
@@ -373,19 +366,19 @@
 "abl" = (
 /obj/effect/landmark/start/servant,
 /turf/open/floor/rogue/herringbone,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "abm" = (
 /obj/effect/landmark/start/sergeant,
 /turf/open/floor/rogue/snow{
 	color = "e6f2ff"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "abn" = (
 /obj/effect/landmark/start/guard_captain,
 /turf/open/floor/rogue/snow{
 	color = "e6f2ff"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "abo" = (
 /obj/structure/roguerock,
 /turf/open/floor/rogue/dirt,
@@ -395,7 +388,7 @@
 /turf/open/floor/rogue/snow{
 	color = "e6f2ff"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "abq" = (
 /obj/effect/landmark/start/armorsmith,
 /turf/open/floor/rogue/dirt,
@@ -403,34 +396,34 @@
 "abr" = (
 /obj/effect/landmark/start/courtagent,
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "abs" = (
 /obj/effect/landmark/start/courtagent,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "abt" = (
 /obj/structure/stairs{
 	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "abu" = (
 /obj/structure/bed/rogue,
 /turf/open/floor/rogue/hay,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "abv" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/hay,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "abw" = (
 /obj/machinery/light/rogue/campfire/densefire,
 /turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "abx" = (
 /obj/structure/fluff/dryingrack,
 /turf/open/floor/rogue/hay,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "aby" = (
 /obj/structure/closet/crate/chest,
 /obj/item/rogueweapon/stoneaxe,
@@ -438,13 +431,13 @@
 /obj/item/rogueweapon/stoneaxe,
 /obj/item/rogueweapon/stoneaxe,
 /turf/open/floor/rogue/hay,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "abz" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1
 	},
 /turf/open/floor/rogue/hay,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "abA" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/suit/roguetown/shirt/tunic/random,
@@ -452,14 +445,14 @@
 /obj/item/clothing/suit/roguetown/shirt/tunic/random,
 /obj/item/clothing/suit/roguetown/shirt/tunic/random,
 /turf/open/floor/rogue/hay,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "abB" = (
 /obj/structure/fluff/customsign{
 	name = "sign - Lumberyard";
 	desc = "Public lumber works. Free shelter for workers."
 	},
 /turf/open/floor/rogue/grasscold,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "abC" = (
 /obj/structure/chair/bench/church{
 	dir = 1
@@ -487,32 +480,32 @@
 	dir = 8
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "abG" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
 	layer = 2.7
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "abH" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/goatmale/tame,
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "abI" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/goat/tame,
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "abJ" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
 	},
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "abK" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "abL" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -520,14 +513,14 @@
 	pixel_x = 6
 	},
 /turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "abM" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "abN" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
@@ -536,7 +529,7 @@
 	pixel_x = 6
 	},
 /turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "abO" = (
 /obj/structure/fluff/railing/border{
 	dir = 1;
@@ -548,7 +541,7 @@
 	pixel_x = -6
 	},
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "abP" = (
 /obj/structure/fluff/railing/border{
 	dir = 1;
@@ -560,7 +553,7 @@
 	pixel_x = -6
 	},
 /turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "abQ" = (
 /obj/structure/fluff/railing/border{
 	pixel_y = -6
@@ -575,7 +568,7 @@
 	pixel_x = 6
 	},
 /turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "abR" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
@@ -588,13 +581,13 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "abS" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
 	},
 /turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "abT" = (
 /obj/machinery/light/rogue/torchholder/c{
 	dir = 8
@@ -607,10 +600,13 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/grasscold,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "abV" = (
-/turf/closed/wall/mineral/rogue/stonebrick,
-/area/rogue/indoors)
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town)
 "abW" = (
 /turf/open/floor/rogue/rooftop{
 	dir = 1;
@@ -621,35 +617,35 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "abY" = (
 /turf/open/floor/rogue/snow{
 	color = "e6f2ff"
 	},
 /turf/closed/wall/mineral/rogue/stonebrick,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "abZ" = (
 /turf/open/floor/rogue/grassred,
 /turf/closed/wall/mineral/rogue/stonebrick,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "aca" = (
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "acb" = (
 /obj/structure/mineral_door/wood{
 	name = "Walters House";
 	lockid = "house2"
 	},
 /turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "acc" = (
 /turf/open/water/bath,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "acd" = (
 /obj/structure/fluff/statue/small,
 /turf/open/water/bath,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "ace" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -658,7 +654,7 @@
 /obj/structure/table/wood/fancy/royalblack,
 /obj/item/flashlight/flare/torch/lantern,
 /turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "acf" = (
 /obj/structure/closet/crate/roguecloset/inn/south,
 /obj/item/natural/bundle/cloth,
@@ -670,7 +666,7 @@
 	desc = "A thick robe meant to be used after baths"
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "acg" = (
 /obj/item/roguekey/houses/house2,
 /obj/item/roguekey/houses/house2,
@@ -679,17 +675,20 @@
 /obj/item/roguekey/houses/house2,
 /obj/structure/closet/crate/chest/neu,
 /turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "ach" = (
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors)
+/obj/structure/flora/roguetree/snow{
+	icon_state = "tree6"
+	},
+/turf/open/floor/rogue/snow,
+/area/rogue/outdoors/town)
 "aci" = (
 /obj/structure/mineral_door/wood{
 	name = "house ii";
 	lockid = "house2"
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "acj" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/herringbone,
@@ -699,25 +698,27 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "acl" = (
 /obj/structure/stairs{
 	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "acm" = (
 /obj/structure/mineral_door/wood{
 	name = "house ii";
 	lockid = "house2"
 	},
 /turf/open/floor/rogue/blocks,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "acn" = (
-/obj/structure/closet/crate/chest/neu,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/obj/effect/decal/herringbone{
+	dir = 9
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/tavern)
 "aco" = (
 /obj/machinery/light/rogue/lanternpost{
 	dir = 1
@@ -725,13 +726,13 @@
 /turf/open/floor/rogue/snow{
 	color = "e6f2ff"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "acp" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "acq" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -740,14 +741,14 @@
 	pixel_y = 10
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "acr" = (
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "acs" = (
 /turf/open/floor/rogue/carpet,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "act" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/rogueweapon/huntingknife/chefknife{
@@ -770,45 +771,43 @@
 /obj/item/reagent_containers/glass/bowl,
 /obj/item/cooking/pan,
 /turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "acu" = (
 /obj/structure/roguewindow/openclose{
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "acv" = (
 /obj/structure/table/wood,
 /turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "acw" = (
 /obj/machinery/light/rogue/oven/west,
 /turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "acx" = (
 /obj/structure/chair/bench/couch{
 	dir = 1
 	},
 /obj/structure/chair/wood/rogue/fancy,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "acz" = (
 /obj/structure/closet/crate/roguecloset/inn/south,
 /obj/structure/fluff/railing/border{
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "acA" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "acB" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/obj/structure/flora/roguegrass/pyroclasticflowers,
+/turf/open/floor/rogue/grasscold,
+/area/rogue/outdoors/town)
 "acC" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood3"
@@ -816,7 +815,7 @@
 /obj/item/reagent_containers/glass/bottle/waterskin,
 /obj/item/bedroll,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "acD" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood3"
@@ -824,100 +823,93 @@
 /obj/item/storage/backpack/rogue/backpack,
 /obj/item/needle,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "acE" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "acF" = (
-/turf/open/transparent/openspace,
-/area/rogue/indoors)
+/obj/machinery/light/rogue/firebowl/stump,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "acG" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "acH" = (
 /obj/structure/fermenting_barrel/water,
 /turf/open/floor/rogue/blocks,
-/area/rogue/under/cave)
+/area/rogue/indoors/town)
 "acI" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "acJ" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
-"acK" = (
-/obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "acL" = (
-/obj/structure/roguetent,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/turf/open/floor/rogue/hay,
+/area/rogue/outdoors/town)
 "acM" = (
 /turf/closed/wall/mineral/rogue/decowood,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "acN" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "acP" = (
 /obj/structure/bed/rogue/inn/double,
 /obj/item/bedsheet/rogue/fabric_double,
 /turf/open/floor/rogue/carpet,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "acQ" = (
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/carpet,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "acS" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "acT" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "acU" = (
 /obj/machinery/light/rogue/torchholder{
 	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "acV" = (
 /obj/structure/mineral_door/wood{
 	name = "door";
 	lockid = "house2"
 	},
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "acW" = (
 /obj/structure/fluff/millstone{
 	pixel_y = 10
 	},
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "acX" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "acY" = (
 /obj/structure/spacevine,
 /obj/structure/flora/roguegrass/water,
@@ -926,19 +918,19 @@
 "acZ" = (
 /obj/machinery/light/rogue/oven/south,
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "ada" = (
 /turf/open/floor/rogue/snow{
 	color = "e6f2ff"
 	},
-/area/rogue/indoors)
+/area/rogue/outdoors/town)
 "adb" = (
 /obj/structure/fermenting_barrel/water,
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "adc" = (
 /turf/closed/wall/mineral/rogue/wood/window,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "add" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/mudcrab{
 	dir = 4
@@ -946,8 +938,12 @@
 /turf/open/water/swamp,
 /area/rogue/under/cave)
 "ade" = (
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors)
+/obj/structure/stairs{
+	icon_state = "stairs";
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town)
 "adf" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -956,18 +952,18 @@
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "adg" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/outdoors/woods)
 "adh" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "adi" = (
 /obj/structure/bed/rogue,
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "adj" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -978,7 +974,7 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "adk" = (
 /obj/structure/flora/roguegrass/water,
 /turf/open/floor/rogue/dirt/ambush,
@@ -986,7 +982,7 @@
 "adl" = (
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "adn" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grasscold,
@@ -1005,12 +1001,12 @@
 /obj/item/book/rogue/tales3,
 /obj/item/book/rogue/knowledge1,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "adS" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/reagent_containers/glass/bucket/pot,
 /turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "ael" = (
 /obj/effect/landmark/start/adventurerlate{
 	icon_state = "arrow";
@@ -1022,28 +1018,27 @@
 /obj/structure/chair/stool/rogue,
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "age" = (
-/obj/effect/decal/cobbleedge{
-	dir = 2
+/turf/open/water/river{
+	icon_state = "rockwd";
+	dir = 1
 	},
-/obj/structure/fluff/dryingrack,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "ahG" = (
 /obj/structure/fluff/walldeco/customflag,
 /turf/closed/wall/mineral/rogue/wood,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "aiO" = (
 /obj/machinery/light/rogue/lanternpost{
 	dir = 1
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "ajr" = (
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/dirt,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "aka" = (
 /obj/structure/flora/roguetree/normal{
 	icon_state = "free2"
@@ -1061,24 +1056,24 @@
 /obj/item/customblank,
 /obj/item/customblank,
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "akp" = (
 /obj/structure/stairs{
 	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "amn" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
 	},
 /turf/open/floor/rogue/grasscold,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "anh" = (
 /obj/machinery/light/rogue/lanternpost,
 /turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "aoQ" = (
 /obj/structure/spacevine,
 /turf/open/floor/rogue/dirt/ambush,
@@ -1120,7 +1115,7 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "atx" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -1147,7 +1142,7 @@
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "auM" = (
 /mob/living/simple_animal/bird,
 /turf/open/transparent/openspace,
@@ -1171,10 +1166,13 @@
 	},
 /obj/structure/bars/shop,
 /turf/open/floor/rogue/herringbone,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "awH" = (
-/turf/closed/wall/mineral/rogue/wooddark,
-/area/rogue/outdoors/mountains)
+/obj/structure/flora/roguetree/snow{
+	icon_state = "tree9"
+	},
+/turf/open/floor/rogue/snow,
+/area/rogue/outdoors/town)
 "ayX" = (
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/snow{
@@ -1182,11 +1180,9 @@
 	},
 /area/rogue/outdoors/rtfield)
 "ayZ" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town)
 "azg" = (
 /turf/closed/wall/mineral/rogue/tent,
 /area/rogue/outdoors/mountains)
@@ -1200,7 +1196,7 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "aCh" = (
 /obj/structure/spacevine,
 /turf/open/water/swamp,
@@ -1217,7 +1213,7 @@
 	desc = "The inn of the Frozen Summit outpost. Where tales come to begin and die."
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "aEv" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -1233,7 +1229,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "aGh" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/dirt,
@@ -1251,7 +1247,7 @@
 /obj/item/seeds/wheat/oat,
 /obj/item/seeds/wheat,
 /turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "aJD" = (
 /obj/item/reagent_containers/food/snacks/crow,
 /turf/open/floor/rogue/naturalstone,
@@ -1259,7 +1255,7 @@
 "aJP" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "aJW" = (
 /obj/item/seeds/cabbage,
 /obj/item/seeds/cabbage,
@@ -1272,11 +1268,11 @@
 /obj/item/seeds/onion,
 /obj/structure/closet/crate/chest/wicker,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "aKS" = (
-/obj/machinery/light/rogue/oven/south,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/obj/effect/landmark/start/villager,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/town)
 "aOM" = (
 /obj/structure/fermenting_barrel/hagwoodbitter,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -1298,7 +1294,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "aRl" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -1315,7 +1311,7 @@
 /area/rogue/indoors/town/church)
 "aUm" = (
 /turf/closed/wall/mineral/rogue/wooddark/end,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "aVf" = (
 /obj/structure/closet/crate/chest/neu_iron,
 /obj/item/reagent_containers/glass/bottle/rogue/wine,
@@ -1354,7 +1350,7 @@
 "aYy" = (
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "aZe" = (
 /turf/closed/mineral/random/rogue/high,
 /area/rogue/outdoors/beach)
@@ -1365,17 +1361,17 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "bdY" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/reagent_containers/glass/bucket/pot/stone,
 /turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "bea" = (
 /turf/open/floor/rogue/rooftop{
 	dir = 1
 	},
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "bez" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /obj/structure/roguemachine/atm,
@@ -1402,11 +1398,11 @@
 	pixel_x = 8
 	},
 /turf/open/floor/carpet/red,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "bmC" = (
 /obj/structure/fluff/walldeco/artificerflag,
 /turf/closed/wall/mineral/rogue/stonebrick,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "bmP" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf,
 /turf/open/floor/rogue/dirt/road,
@@ -1426,13 +1422,13 @@
 	dir = 8
 	},
 /turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "bpz" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "bpV" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -1440,14 +1436,14 @@
 	pixel_x = 8
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "bqr" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
 	},
 /obj/structure/fluff/railing/stonehedge,
 /turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "bsj" = (
 /obj/structure/bed/rogue/inn/hay,
 /obj/effect/landmark/start/villager,
@@ -1465,7 +1461,7 @@
 	pixel_y = 7
 	},
 /turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "btI" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -1479,7 +1475,7 @@
 	},
 /obj/item/mortar,
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "bve" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /obj/structure/fluff/railing/border{
@@ -1488,15 +1484,15 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "bvp" = (
 /obj/structure/bed/rogue/inn/wooldouble,
 /turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "bvV" = (
 /obj/machinery/light/rogue/lanternpost,
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "bwp" = (
 /obj/structure/rack/rogue/shelf/big,
 /obj/structure/rack/rogue/shelf,
@@ -1525,20 +1521,17 @@
 	pixel_x = -6
 	},
 /turf/closed/wall/mineral/rogue/wood,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "bzF" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/outdoors/mountains)
+/turf/closed/wall/mineral/rogue/stone/moss,
+/area/rogue/outdoors/town)
 "bzL" = (
 /obj/machinery/light/rogue/torchholder/c{
 	dir = 4
 	},
 /obj/structure/plough,
 /turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "bAL" = (
 /obj/structure/flora/roguegrass,
 /obj/effect/decal/mossy{
@@ -1546,7 +1539,7 @@
 	},
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "bBY" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -1563,13 +1556,13 @@
 	},
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "bDN" = (
 /obj/structure/roguewindow/openclose{
 	dir = 4
 	},
 /turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "bDW" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -1580,7 +1573,7 @@
 	},
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "bEC" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -1592,8 +1585,8 @@
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/rtfield)
 "bGi" = (
-/turf/open/floor/rogue/wood/herringbone,
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/outdoors/town)
 "bHS" = (
 /obj/structure/telescope,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -1607,25 +1600,20 @@
 "bIq" = (
 /obj/structure/closet/crate/roguecloset/inn/south,
 /turf/open/floor/rogue/wood,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "bIu" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "bJz" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/natural/feather,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/outdoors/mountains)
+/obj/effect/spawner/roguemap/stump,
+/turf/open/floor/rogue/grasscold,
+/area/rogue/outdoors/town)
 "bJP" = (
 /obj/structure/bed/rogue/inn,
 /obj/item/bedsheet/rogue/pelt,
 /turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/under/cave)
+/area/rogue/indoors/town)
 "bKz" = (
 /obj/structure/stairs{
 	icon_state = "stairs";
@@ -1636,11 +1624,11 @@
 "bKO" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "bLq" = (
 /obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "bLv" = (
 /obj/structure/flora/roguetree/stump/log,
 /turf/open/water/swamp,
@@ -1671,7 +1659,7 @@
 	dir = 9
 	},
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "bOv" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/rogue/blocks,
@@ -1710,12 +1698,6 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains)
-"bSo" = (
-/obj/effect/decal/cobbleedge{
-	dir = 2
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
 "bUo" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/dirt/road,
@@ -1728,20 +1710,20 @@
 	pixel_y = 7
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "bWh" = (
 /obj/machinery/light/rogue/lanternpost{
 	dir = 1
 	},
 /turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "bWn" = (
 /obj/structure/chair/bench/coucha/r,
 /obj/machinery/light/rogue/wallfire{
 	pixel_y = 32
 	},
 /turf/open/floor/rogue/wood/herringbone,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "bWt" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -1754,13 +1736,13 @@
 	pixel_y = 26
 	},
 /turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "bXh" = (
 /obj/structure/stairs{
 	dir = 4
 	},
 /turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "bXj" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobblerock,
@@ -1781,20 +1763,20 @@
 "bYu" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/open/floor/rogue/wood/herringbone,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "bYv" = (
 /turf/closed/wall/mineral/rogue/pipe,
-/area/rogue/under/cave)
+/area/rogue/indoors/town)
 "bYw" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "bYR" = (
 /obj/structure/fluff/walldeco/stone,
 /turf/closed/wall/mineral/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "bZI" = (
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/rogue/blocks,
@@ -1805,7 +1787,7 @@
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "ccX" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors/town)
@@ -1836,7 +1818,7 @@
 	pixel_x = 8
 	},
 /turf/open/floor/rogue/grasscold,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "chq" = (
 /obj/structure/rack/rogue/shelf/big,
 /obj/item/rogueweapon/pitchfork{
@@ -1852,7 +1834,7 @@
 	pixel_y = 44
 	},
 /turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "chB" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -1860,10 +1842,10 @@
 	pixel_x = 6
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "cij" = (
 /turf/closed/wall/mineral/rogue/decowood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "cjK" = (
 /obj/structure/closet/crate/roguecloset/inn,
 /obj/item/clothing/shoes/roguetown/boots/clothlinedanklets,
@@ -1879,7 +1861,7 @@
 "ckv" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/dirt/road,
-/area/rogue)
+/area/rogue/outdoors/town)
 "ckP" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -1894,7 +1876,7 @@
 "clC" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/grasscold,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "clT" = (
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
@@ -1926,30 +1908,31 @@
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "cpp" = (
 /obj/structure/mineral_door/wood/towner/anyone{
 	pixel_x = -1
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "cqq" = (
-/obj/structure/roguewindow/openclose{
+/obj/machinery/light/rogue/torchholder{
+	icon_state = "torchwall1";
 	dir = 8
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/town)
 "cry" = (
 /obj/machinery/light/rogue/torchholder{
 	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "cty" = (
 /obj/structure/mineral_door/wood/towner/blacksmith,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "ctF" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
@@ -1957,21 +1940,21 @@
 /turf/open/floor/rogue/snow{
 	color = "e6f2ff"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "cui" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
 	},
 /turf/open/floor/rogue/twig/platform,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "cuY" = (
-/obj/structure/fluff/railing/wood,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/indoors)
+/obj/structure/flora/newtree,
+/turf/open/floor/rogue/grasscold,
+/area/rogue/outdoors/town)
 "cvr" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "cvy" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/cavetroll,
 /turf/open/floor/rogue/naturalstone,
@@ -2001,11 +1984,11 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "cxl" = (
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "cxR" = (
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -2021,16 +2004,16 @@
 	},
 /obj/item/kitchen/rollingpin,
 /turf/open/floor/rogue/herringbone,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "cyW" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblack,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "czi" = (
 /turf/open/water/bath,
-/area/rogue/indoors/town/bath)
+/area/rogue/indoors/town/church)
 "czz" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach)
@@ -2052,14 +2035,14 @@
 	},
 /obj/item/rogueweapon/sickle,
 /turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "cBU" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/fluff/millstone{
 	pixel_y = 10
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "cBY" = (
 /obj/structure/bed/rogue/inn/double,
 /obj/item/bedsheet/rogue/fabric_double,
@@ -2077,7 +2060,7 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/red,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "cEK" = (
 /obj/structure/flora/junglebush,
 /obj/machinery/light/rogue/torchholder{
@@ -2090,7 +2073,7 @@
 /obj/item/reagent_containers/glass/bucket/wooden,
 /obj/item/broom,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town/garrison)
 "cHj" = (
 /obj/structure/fluff/railing/wood{
 	pixel_x = 1;
@@ -2099,17 +2082,15 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
 "cHF" = (
-/obj/structure/roguewindow/openclose{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/obj/structure/flora/newtree,
+/turf/open/floor/rogue/snow,
+/area/rogue/outdoors/town)
 "cHN" = (
 /obj/effect/decal/wood/herringbone{
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "cIa" = (
 /obj/structure/flora/roguetree/snow{
 	icon_state = "tree5"
@@ -2130,11 +2111,11 @@
 	},
 /obj/machinery/anvil,
 /turf/open/floor/rogue/dirt,
-/area/rogue/indoors)
+/area/rogue/outdoors/town)
 "cJt" = (
 /obj/machinery/light/rogue/cauldron,
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "cKj" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/outdoors/beach)
@@ -2143,11 +2124,11 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "cMa" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/bath)
+/area/rogue/indoors/town/church)
 "cMx" = (
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church)
@@ -2164,15 +2145,11 @@
 	pixel_y = 9
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "cOy" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/kitchen/rollingpin,
-/obj/item/flint,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/obj/structure/flora/roguegrass/swampweed,
+/turf/open/floor/rogue/grasscold,
+/area/rogue/outdoors/town)
 "cOL" = (
 /turf/open/floor/rogue/grasscold,
 /area/rogue/indoors/town/tavern)
@@ -2190,11 +2167,11 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "cPQ" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "cQd" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/outdoors/rtfield)
@@ -2223,7 +2200,7 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "cQZ" = (
 /obj/effect/landmark/start/vagrant,
 /turf/open/floor/rogue/dirt/road,
@@ -2231,26 +2208,23 @@
 "cSr" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "cTU" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/under/cave)
+/area/rogue/indoors/town/garrison)
 "cUx" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
 	},
 /obj/item/chair/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "cUB" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/rtfield)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/indoors/town/garrison)
 "cVQ" = (
 /obj/structure/fluff/traveltile{
 	aportalid = "bogrtout_cave";
@@ -2261,7 +2235,7 @@
 "cWJ" = (
 /obj/structure/closet/crate/drawer,
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "cWP" = (
 /obj/structure/closet/crate/chest/wicker{
 	opened = 1
@@ -2269,7 +2243,7 @@
 /obj/item/fishingrod,
 /obj/item/rogueweapon/shovel/small,
 /turf/open/floor/rogue/snow,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "cXd" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4;
@@ -2278,7 +2252,7 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "cXE" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/grasscold,
@@ -2286,11 +2260,11 @@
 "cXW" = (
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/under/cave)
+/area/rogue/indoors/town/cell)
 "cZg" = (
-/obj/structure/roguetent,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/obj/structure/flora/roguetree/snow,
+/turf/open/floor/rogue/snow,
+/area/rogue/outdoors/town)
 "cZT" = (
 /obj/structure/spacevine,
 /turf/open/floor/rogue/blocks,
@@ -2302,7 +2276,7 @@
 	pixel_x = -4
 	},
 /turf/open/floor/rogue/snow,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "dba" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/far_travel,
@@ -2320,7 +2294,7 @@
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "ddN" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/wood{
@@ -2328,11 +2302,11 @@
 	},
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "dez" = (
 /obj/machinery/light/rogue/cauldron,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "deL" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -2349,13 +2323,13 @@
 	},
 /obj/structure/fluff/railing/stonehedge,
 /turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "dfW" = (
 /obj/structure/roguewindow/openclose{
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "dhx" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/dirt,
@@ -2364,7 +2338,7 @@
 /turf/open/floor/rogue/rooftop/green{
 	dir = 8
 	},
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "dhZ" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -2378,13 +2352,13 @@
 	pixel_y = 7
 	},
 /turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "diq" = (
 /obj/structure/table/wood,
 /obj/item/kitchen/rollingpin,
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "diM" = (
 /obj/structure/flora/ausbushes/genericbush,
 /turf/open/floor/rogue/dirt/road,
@@ -2451,12 +2425,12 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/red,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "dll" = (
 /obj/item/bedsheet/rogue/double_pelt,
 /obj/structure/bed/rogue/inn/double,
 /turf/open/floor/carpet/royalblack,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "dlO" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/wood/herringbone,
@@ -2468,7 +2442,7 @@
 /obj/item/kitchen/rollingpin,
 /obj/item/flint,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "dmh" = (
 /obj/structure/roguemachine/withdraw,
 /turf/open/floor/rogue/blocks,
@@ -2477,7 +2451,7 @@
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "dot" = (
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grasscold,
@@ -2488,19 +2462,19 @@
 	pixel_y = -1
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "dqJ" = (
 /turf/open/floor/rogue/rooftop/green{
 	dir = 4
 	},
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "dqL" = (
 /obj/structure/fluff/dryingrack,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/woods)
 "dsB" = (
 /turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/under/cave)
+/area/rogue/indoors/town/garrison)
 "dtr" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/twig,
@@ -2519,13 +2493,10 @@
 	},
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/transparent/openspace,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "dwh" = (
-/obj/structure/roguewindow,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/twig,
+/area/rogue/outdoors/town)
 "dwP" = (
 /obj/structure/flora/roguetree/normal{
 	icon_state = "free7"
@@ -2533,10 +2504,11 @@
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/woods)
 "dxc" = (
-/obj/structure/bed/rogue/inn/double,
-/obj/item/bedsheet/rogue/double_pelt,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/obj/structure/flora/roguetree/snow{
+	icon_state = "tree5"
+	},
+/turf/open/floor/rogue/snow,
+/area/rogue/outdoors/town)
 "dxn" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -2548,18 +2520,12 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town/bath)
 "dxV" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/natural/feather,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors)
+/turf/open/floor/rogue/grassred,
+/area/rogue/outdoors/town)
 "dzr" = (
 /obj/structure/mineral_door/wood/red,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "dzt" = (
 /turf/open/floor/rogue/tile{
 	icon_state = "chess"
@@ -2570,7 +2536,7 @@
 	dir = 2
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "dBR" = (
 /obj/structure/flora/roguetree/snow{
 	icon_state = "tree6"
@@ -2582,7 +2548,7 @@
 	icon_state = "vertw";
 	dir = 1
 	},
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "dDx" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -2592,7 +2558,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "dDy" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_y = 32
@@ -2601,19 +2567,14 @@
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "dDS" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2.7;
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/obj/structure/flora/roguetree/burnt,
+/turf/open/floor/rogue/snow,
+/area/rogue/outdoors/town)
 "dFC" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/under/cave)
+/area/rogue/indoors/town/garrison)
 "dGC" = (
 /obj/structure/table/wood{
 	icon_state = "longtable";
@@ -2627,13 +2588,13 @@
 /obj/structure/fermenting_barrel/random/beer,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "dHi" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
 	},
 /turf/closed/wall/mineral/rogue/stonebrick,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "dHH" = (
 /obj/structure/wallladder{
 	dir = 1
@@ -2641,7 +2602,7 @@
 /turf/open/floor/rogue/snow{
 	color = "e6f2ff"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "dHO" = (
 /obj/item/natural/stone{
 	icon_state = "stone4"
@@ -2653,18 +2614,18 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/royalblack,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "dJj" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "dJz" = (
 /obj/structure/fluff/railing/wood{
 	pixel_x = 1;
 	pixel_y = -8
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "dKj" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_y = 32
@@ -2687,7 +2648,7 @@
 	lockid = "houseshop"
 	},
 /turf/open/floor/rogue/snow,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "dLO" = (
 /obj/structure/bed/rogue/shit,
 /obj/effect/landmark/start/vagrant,
@@ -2698,7 +2659,7 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "dOa" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_y = 32
@@ -2711,12 +2672,12 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "dPb" = (
 /obj/machinery/light/rogue/oven/south,
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "dPu" = (
 /obj/effect/spawner/roguemap/stump,
 /turf/open/floor/rogue/snow,
@@ -2735,7 +2696,7 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "dRI" = (
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/churchrough,
@@ -2743,7 +2704,7 @@
 "dSe" = (
 /obj/machinery/light/rogue/smelter,
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/indoors)
+/area/rogue/outdoors/town)
 "dSy" = (
 /obj/structure/telescope,
 /turf/open/floor/rogue/twig,
@@ -2766,11 +2727,11 @@
 "dVE" = (
 /obj/effect/landmark/start/villager,
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "dVK" = (
 /obj/structure/bed/rogue/inn/pileofshit,
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "dVQ" = (
 /obj/structure/flora/roguetree/snow{
 	icon_state = "tree6"
@@ -2782,11 +2743,11 @@
 /turf/open/floor/rogue/snow{
 	color = "e6f2ff"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "dWc" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/woodturned,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "dWh" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4
@@ -2796,7 +2757,7 @@
 "dWZ" = (
 /obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "dXm" = (
 /obj/structure/flora/roguetree/snow{
 	icon_state = "tree3"
@@ -2809,7 +2770,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "dXO" = (
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/woods)
@@ -2817,7 +2778,7 @@
 /obj/machinery/light/rogue/hearth,
 /obj/item/reagent_containers/glass/bucket/pot/stone,
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "dYM" = (
 /obj/structure/fluff/walldeco/rpainting,
 /turf/closed/wall/mineral/rogue/wood,
@@ -2832,7 +2793,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "ebf" = (
 /obj/structure/flora/roguegrass,
 /obj/effect/decal/mossy{
@@ -2840,7 +2801,7 @@
 	},
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "ebZ" = (
 /obj/structure/fluff/railing/stonehedge{
 	dir = 4
@@ -2852,9 +2813,9 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/woods)
 "edS" = (
-/obj/structure/roguewindow/openclose,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/obj/structure/flora/newtree,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/town)
 "efe" = (
 /obj/effect/landmark/start/orphan,
 /turf/open/floor/rogue/cobblerock,
@@ -2863,14 +2824,14 @@
 /obj/structure/bed/rogue/inn/double,
 /obj/item/bedsheet/rogue/fabric_double,
 /turf/open/floor/rogue/wood,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "efp" = (
 /obj/effect/decal/mossy,
 /obj/effect/decal/cobbleedge{
 	dir = 6
 	},
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "eft" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/item/mortar,
@@ -2878,7 +2839,7 @@
 /area/rogue/indoors/town/church)
 "egn" = (
 /turf/open/floor/rogue/woodturned,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "ehm" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -2894,13 +2855,13 @@
 /obj/item/reagent_containers/glass/bowl,
 /obj/item/reagent_containers/glass/bowl,
 /turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "eik" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "eiB" = (
 /obj/structure/flora/roguegrass/swampweed,
 /turf/open/water/swamp,
@@ -2908,14 +2869,10 @@
 "eiW" = (
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "ejK" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/fluff/millstone{
-	pixel_y = 10
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/turf/closed/wall/mineral/rogue/stone,
+/area/rogue/under/town)
 "ekN" = (
 /turf/closed/wall/mineral/rogue/decostone/end{
 	dir = 1
@@ -2925,7 +2882,7 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /obj/structure/closet/crate/chest/neu,
 /turf/open/floor/rogue/cobble,
-/area/rogue/under/cave)
+/area/rogue/indoors/town)
 "elo" = (
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/dirt/road,
@@ -2933,7 +2890,7 @@
 "ely" = (
 /obj/effect/spawner/roguemap/stump,
 /turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "elB" = (
 /obj/machinery/light/rogue/torchholder{
 	icon_state = "torchwall1";
@@ -2949,7 +2906,7 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "ent" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains)
@@ -2973,7 +2930,7 @@
 	pixel_y = -8
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "eop" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_y = 32
@@ -2994,7 +2951,7 @@
 	pixel_y = -1
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "esK" = (
 /obj/structure/flora/roguegrass/thorn_bush,
 /turf/open/floor/rogue/dirt/road,
@@ -3015,7 +2972,7 @@
 /obj/item/reagent_containers/food/snacks/grown/berries/rogue,
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "etS" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_y = 32
@@ -3025,20 +2982,20 @@
 "evH" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "eyb" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "eAz" = (
 /obj/structure/roguerock,
 /turf/open/water/river{
 	icon_state = "rockwd";
 	dir = 4
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "eGj" = (
 /obj/structure/stairs,
 /obj/structure/fluff/railing/border{
@@ -3071,22 +3028,22 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/woodturned,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "eIo" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/cobble,
-/area/rogue/under/cave)
+/area/rogue/indoors/town)
 "eJJ" = (
 /obj/structure/chair/wood{
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblack,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "eKm" = (
 /obj/effect/landmark/start/artificer,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "eLM" = (
 /obj/structure/underworld/barrier,
 /turf/open/floor/rogue/dirt,
@@ -3096,29 +3053,29 @@
 	dir = 9
 	},
 /turf/open/floor/rogue/snow,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "eNV" = (
 /obj/structure/fluff/railing/wood{
 	pixel_y = -8
 	},
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "eQb" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "eQn" = (
 /turf/open/floor/rogue/rooftop/green{
 	dir = 1
 	},
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "eSe" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
 	},
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "eTz" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -3131,7 +3088,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "eUq" = (
 /obj/effect/landmark/start/adventurerlate{
 	dir = 1
@@ -3154,18 +3111,18 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/grasscold,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "eVl" = (
 /obj/effect/decal/cobbleedge,
 /obj/structure/fluff/railing/border{
 	dir = 5
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "eVW" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "eWi" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -3190,18 +3147,20 @@
 	dir = 9
 	},
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "fcm" = (
-/obj/structure/rack/rogue/shelf/biggest,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/obj/structure/flora/roguetree/snow{
+	icon_state = "tree8"
+	},
+/turf/open/floor/rogue/grasscold,
+/area/rogue/outdoors/town)
 "fcC" = (
 /obj/effect/decal/mossy,
 /obj/effect/decal/cobbleedge{
 	dir = 10
 	},
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "fcY" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/wood/herringbone,
@@ -3212,23 +3171,14 @@
 	},
 /obj/structure/fluff/dryingrack,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "fdy" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/obj/structure/rack/rogue/shelf/biggest,
-/obj/item/kitchen/spoon,
-/obj/item/kitchen/spoon,
-/obj/item/kitchen/fork,
-/obj/item/kitchen/fork,
-/obj/item/kitchen/fork,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/turf/closed/wall/mineral/rogue/decostone,
+/area/rogue/outdoors/town)
 "fdT" = (
 /obj/effect/landmark/events/haunts,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "feq" = (
 /obj/structure/flora/newbranch/leafless{
 	dir = 1
@@ -3252,13 +3202,13 @@
 "fjd" = (
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "fjz" = (
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 4
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "fkd" = (
 /obj/structure/fluff/walldeco/innsign{
 	name = "The Dark Oak";
@@ -3266,7 +3216,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "fki" = (
 /obj/structure/mineral_door/wood/window,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -3276,7 +3226,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/herringbone,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "flD" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -3290,11 +3240,11 @@
 	lockid = "healershut"
 	},
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "fna" = (
 /obj/structure/fermenting_barrel/water,
 /turf/open/floor/rogue/dirt,
-/area/rogue/under/cave)
+/area/rogue/under/town)
 "fnO" = (
 /obj/structure/flora/roguetree/stump/log,
 /turf/open/floor/rogue/dirt/road,
@@ -3304,7 +3254,7 @@
 /obj/machinery/light/rogue/hearth,
 /obj/item/reagent_containers/glass/bucket/pot,
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "fsg" = (
 /obj/structure/chair/stool/rogue,
 /obj/structure/rack/rogue/shelf,
@@ -3324,7 +3274,7 @@
 	pixel_y = 45
 	},
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "fsD" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/transparent/openspace,
@@ -3339,14 +3289,14 @@
 /obj/structure/bed/rogue/inn/double,
 /obj/item/bedsheet/rogue/double_pelt,
 /turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "ftj" = (
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/tavern)
 "ftz" = (
 /turf/open/floor/rogue/rooftop/green/corner1,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "fuY" = (
 /obj/structure/table/wood{
 	icon_state = "longtable";
@@ -3370,13 +3320,13 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /obj/structure/closet/crate/drawer,
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "fwl" = (
 /obj/structure/closet/crate/chest/old_crate,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "fwr" = (
 /obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/grasscold,
@@ -3388,20 +3338,18 @@
 	},
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "fyG" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 4
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/outdoors/rtfield)
+/obj/machinery/light/rogue/firebowl/standing,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/indoors/town)
 "fzp" = (
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "fzT" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "fAA" = (
 /turf/closed/wall/mineral/rogue/decostone/center,
 /area/rogue/indoors/town/church)
@@ -3411,7 +3359,7 @@
 	pixel_y = -1
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "fDp" = (
 /obj/structure/closet/crate/chest{
 	lockid = "priest"
@@ -3429,7 +3377,7 @@
 	},
 /obj/structure/fluff/dryingrack,
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "fFk" = (
 /obj/structure/roguerock,
 /turf/open/floor/rogue/naturalstone,
@@ -3444,7 +3392,7 @@
 	pixel_x = 6
 	},
 /turf/open/floor/rogue/twig/platform,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "fHT" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -3455,7 +3403,7 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "fIZ" = (
 /obj/structure/fluff/walldeco/innsign{
 	pixel_x = 32;
@@ -3463,7 +3411,7 @@
 	desc = "The inn of the Frozen Summit outpost. Where tales come to begin and die."
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "fJa" = (
 /obj/item/grown/log/tree/stake,
 /obj/structure/spacevine,
@@ -3485,8 +3433,8 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave)
 "fJU" = (
-/turf/closed/wall/mineral/rogue/wooddark/vertical,
-/area/rogue/outdoors/rtfield)
+/turf/closed/wall/mineral/rogue/stone,
+/area/rogue/indoors/town/garrison)
 "fKS" = (
 /obj/effect/landmark/mapGenerator/rogue/roguetownfield{
 	endTurfX = 155;
@@ -3500,19 +3448,19 @@
 	dir = 9
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "fLF" = (
 /turf/open/floor/rogue/rooftop{
 	dir = 8
 	},
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "fNu" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
 	},
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/hay,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "fOw" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/hexstone,
@@ -3520,13 +3468,11 @@
 "fOB" = (
 /obj/machinery/light/rogue/oven/south,
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "fOW" = (
-/obj/structure/mineral_door/wood{
-	lockid = "house6"
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/wood,
+/area/rogue/outdoors/town)
 "fPC" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -3536,18 +3482,18 @@
 	pixel_y = 32
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "fPM" = (
 /obj/structure/table/wood{
 	icon_state = "longtable_mid"
 	},
 /obj/structure/bars/shop,
 /turf/open/floor/rogue/herringbone,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "fQo" = (
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/snow,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town/garrison)
 "fQL" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_y = -32
@@ -3556,7 +3502,7 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/red,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "fQW" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1
@@ -3569,14 +3515,14 @@
 "fRU" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "fTZ" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /obj/structure/closet/crate/chest/neu,
 /obj/item/storage/roguebag,
 /obj/item/storage/roguebag,
 /turf/open/floor/rogue/cobble,
-/area/rogue/under/cave)
+/area/rogue/indoors/town)
 "fUx" = (
 /obj/item/grown/log/tree/stake,
 /turf/closed/mineral/random/rogue/high,
@@ -3585,12 +3531,12 @@
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/rogue/grasscold,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "fUV" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/reagent_containers/glass/bucket/pot,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "fXd" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -3601,7 +3547,7 @@
 	pixel_y = -6
 	},
 /turf/open/floor/rogue/twig/platform,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "fXo" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/suit/roguetown/shirt/robe/astrata,
@@ -3618,14 +3564,14 @@
 	pixel_y = 12
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "fZv" = (
 /obj/structure/fluff/railing/wood{
 	pixel_y = 17
 	},
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/dirt,
-/area/rogue/indoors)
+/area/rogue/outdoors/town)
 "fZy" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/effect/decal/mossy{
@@ -3633,11 +3579,11 @@
 	},
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "gag" = (
 /obj/structure/fluff/millstone,
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "gaE" = (
 /obj/structure/closet/crate/roguecloset/inn/south,
 /turf/open/floor/rogue/woodturned,
@@ -3645,11 +3591,7 @@
 "gaK" = (
 /obj/structure/mineral_door/wood/towner/anyone,
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/rtfield)
-"gaQ" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "gbn" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town)
@@ -3674,7 +3616,7 @@
 	pixel_x = 8
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "gdM" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/dirt/road,
@@ -3684,7 +3626,7 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "get" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/woods)
@@ -3695,16 +3637,16 @@
 	desc = "A small place for a small creature. Looks comfy"
 	},
 /turf/open/floor/carpet/royalblack,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "ggR" = (
 /obj/machinery/light/rogue/oven/south,
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "ght" = (
 /obj/structure/closet/crate/chest,
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "giU" = (
 /obj/structure/stairs{
 	icon_state = "stairs";
@@ -3715,19 +3657,19 @@
 "gjv" = (
 /obj/structure/mineral_door/wood/towner/anyone,
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "gjU" = (
 /obj/structure/flora/roguetree/snow{
 	icon_state = "tree8"
 	},
 /turf/open/floor/rogue/snow,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "gkl" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/carpet/red,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "gkU" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/indoors/town/tavern)
@@ -3750,25 +3692,25 @@
 	},
 /obj/machinery/light/rogue/cauldron,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "gnm" = (
 /obj/structure/roguewindow/openclose{
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "gog" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_y = 32
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "goi" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 8
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "goI" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
@@ -3800,7 +3742,7 @@
 	},
 /obj/item/roguekey/lord,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "gqo" = (
 /turf/open/water/river{
 	icon_state = "rockwd";
@@ -3813,14 +3755,14 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "gsR" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/mountains)
 "gut" = (
 /obj/structure/stairs/d,
 /turf/open/floor/rogue/wood/herringbone,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "guA" = (
 /obj/item/natural/stone{
 	icon_state = "stone4"
@@ -3832,14 +3774,14 @@
 	keylock = 0
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "gwT" = (
 /obj/structure/fluff/railing/wood{
 	pixel_y = 17
 	},
 /obj/machinery/light/rogue/forge,
 /turf/open/floor/rogue/dirt,
-/area/rogue/indoors)
+/area/rogue/outdoors/town)
 "gxe" = (
 /obj/structure/flora/roguetree/stump/log,
 /turf/open/floor/rogue/dirt,
@@ -3870,7 +3812,7 @@
 /obj/item/reagent_containers/glass/bowl,
 /obj/item/reagent_containers/glass/bowl,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "gCf" = (
 /obj/structure/flora/rock,
 /turf/open/floor/rogue/dirt/road,
@@ -3886,7 +3828,7 @@
 	pixel_y = -8
 	},
 /turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "gCD" = (
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town/tavern)
@@ -3910,11 +3852,11 @@
 	pixel_x = -10
 	},
 /turf/open/floor/rogue/blocks,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "gIY" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "gLg" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
@@ -3924,18 +3866,18 @@
 	dir = 8
 	},
 /turf/open/transparent/openspace,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "gNb" = (
 /obj/item/roguebin/water,
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "gOm" = (
 /obj/structure/closet/crate/chest/crate,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "gQy" = (
 /obj/machinery/light/rogue/torchholder{
 	icon_state = "torchwall1";
@@ -3948,7 +3890,7 @@
 	dir = 2;
 	icon_state = "roofg"
 	},
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "gRn" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/item/reagent_containers/glass/mortar,
@@ -3959,7 +3901,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "gSr" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/reagent_containers/glass/bucket/pot/stone,
@@ -3987,7 +3929,7 @@
 	dir = 1
 	},
 /turf/open/transparent/openspace,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "gVN" = (
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/cobblerock,
@@ -3995,17 +3937,17 @@
 "gVZ" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "gWs" = (
 /obj/item/roguegear,
 /turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/under/cave)
+/area/rogue/indoors/town)
 "gWx" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "gXd" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -4020,11 +3962,11 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "gYC" = (
 /obj/structure/fluff/grindwheel,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "gYF" = (
 /obj/structure/bed/rogue/inn/hay,
 /obj/machinery/light/rogue/wallfire/candle/r,
@@ -4041,7 +3983,7 @@
 /obj/item/rope/chain,
 /obj/item/rope/chain,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town/garrison)
 "haP" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
@@ -4051,20 +3993,20 @@
 /area/rogue/indoors/town/tavern)
 "hbf" = (
 /turf/open/floor/rogue/blocks/platform,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "hbi" = (
 /turf/open/floor/rogue/naturalstone,
 /turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "hbl" = (
 /turf/open/floor/rogue/dirt,
-/area/rogue/indoors)
+/area/rogue/outdoors/town)
 "hdr" = (
 /obj/structure/roguewindow/openclose{
 	dir = 1
 	},
 /turf/open/floor/rogue/wood/herringbone,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "hdL" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/item/reagent_containers/glass/cup/wooden,
@@ -4087,8 +4029,8 @@
 /turf/open/water/swamp,
 /area/rogue/under/cave)
 "hfa" = (
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue)
+/turf/closed/mineral/random/rogue,
+/area/rogue/outdoors/town)
 "hhU" = (
 /obj/structure/fluff/railing/wood,
 /obj/structure/table/wood{
@@ -4096,7 +4038,7 @@
 	},
 /obj/item/reagent_containers/glass/mortar,
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "hiA" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/floor/rogue/dirt,
@@ -4111,12 +4053,12 @@
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "hjJ" = (
 /obj/structure/rack/rogue/shelf/big,
 /obj/item/kitchen/rollingpin,
 /turf/open/floor/rogue/herringbone,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "hkz" = (
 /obj/item/reagent_containers/glass/mortar,
 /obj/structure/table/wood{
@@ -4125,7 +4067,7 @@
 	},
 /obj/item/mortar,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "hlu" = (
 /obj/structure/underworld/barrier,
 /turf/open/floor/rogue/dirt/road,
@@ -4158,7 +4100,7 @@
 "hnK" = (
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "hnT" = (
 /obj/machinery/anvil,
 /turf/open/floor/rogue/blocks,
@@ -4183,20 +4125,20 @@
 	dir = 1
 	},
 /turf/open/transparent/openspace,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "hre" = (
 /obj/structure/handcart{
 	icon_state = "cart-empty";
 	dir = 8
 	},
 /turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "hrK" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
 	},
 /turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "hsN" = (
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/tile/bath,
@@ -4207,13 +4149,13 @@
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "huD" = (
 /obj/structure/roguewindow/openclose{
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "huO" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/mountains)
@@ -4223,7 +4165,7 @@
 	},
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/under/cave)
+/area/rogue/indoors/town)
 "hvE" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/beach)
@@ -4240,25 +4182,18 @@
 "hxJ" = (
 /obj/machinery/light/rogue/lanternpost,
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "hxX" = (
 /obj/structure/bookcase,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town/garrison)
 "hDp" = (
 /obj/structure/fluff/railing/fence{
 	icon_state = "fence";
 	dir = 8
 	},
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
-"hEi" = (
-/obj/structure/closet/crate/drawer,
-/obj/structure/fluff/walldeco/rpainting/forest{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "hGg" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
@@ -4269,13 +4204,13 @@
 /obj/structure/bed/rogue/inn/wooldouble,
 /obj/item/bedsheet/rogue/double_pelt,
 /turf/open/floor/carpet/red,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "hGT" = (
 /turf/open/floor/rogue/twig/platform,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "hHC" = (
 /turf/open/floor/rogue/wood,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "hHM" = (
 /obj/structure/stairs{
 	icon_state = "stairs";
@@ -4289,7 +4224,7 @@
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "hKA" = (
 /turf/open/water/river{
 	icon_state = "rockwd"
@@ -4300,12 +4235,12 @@
 	dir = 10
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "hLv" = (
 /obj/structure/table/church,
 /obj/item/reagent_containers/glass/bucket/pot/stone,
 /turf/open/floor/rogue/blocks,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "hMb" = (
 /obj/structure/stairs{
 	dir = 8
@@ -4317,7 +4252,7 @@
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "hOV" = (
 /obj/item/reagent_containers/food/snacks/smallrat/dead,
 /turf/open/floor/rogue/cobblerock,
@@ -4352,20 +4287,20 @@
 /obj/machinery/light/rogue/wallfire/candle/r,
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "hSx" = (
 /turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "hSZ" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "hTt" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "hTA" = (
 /obj/structure/closet/crate/coffin/vampire,
 /turf/open/floor/rogue/blocks,
@@ -4377,7 +4312,7 @@
 	},
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "hUu" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -4387,14 +4322,14 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "hVe" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave)
 "hVT" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "hWk" = (
 /turf/open/floor/rogue/snow,
 /area/rogue/outdoors/mountains)
@@ -4410,21 +4345,21 @@
 /turf/open/floor/rogue/snow{
 	color = "e6f2ff"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "hXU" = (
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/blocks,
-/area/rogue/under/cave)
+/area/rogue/indoors/town)
 "hZB" = (
 /obj/structure/closet/crate/drawer,
 /obj/structure/fluff/walldeco/rpainting/forest{
 	pixel_y = 32
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "iax" = (
 /turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/under/cave)
+/area/rogue/indoors/town)
 "ibf" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -4432,7 +4367,7 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "ibq" = (
 /obj/item/rogueweapon/sword/uchigatana,
 /obj/structure/flora/roguegrass/water/reeds,
@@ -4443,8 +4378,9 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/woods)
 "icA" = (
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/bath)
+/obj/structure/spacevine,
+/turf/closed/mineral/random/rogue/high,
+/area/rogue/indoors/town)
 "idt" = (
 /obj/structure/closet/crate/chest{
 	icon_state = "woodchestalt";
@@ -4453,7 +4389,7 @@
 /obj/item/rogueweapon/stoneaxe/woodcut,
 /obj/item/rogueweapon/shovel,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "idG" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_y = 32
@@ -4471,7 +4407,7 @@
 	pixel_y = -8
 	},
 /turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "igB" = (
 /turf/open/lava/item_acid,
 /area/rogue/outdoors/rtfield)
@@ -4479,7 +4415,7 @@
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 8
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "iiH" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -4517,7 +4453,7 @@
 	pixel_x = 8
 	},
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "inM" = (
 /turf/closed/wall/mineral/rogue/decowood/vert,
 /area/rogue/outdoors/rtfield)
@@ -4540,13 +4476,13 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "isk" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
 	},
 /turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "isP" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -4559,21 +4495,15 @@
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/mountains)
 "itz" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/obj/structure/fluff/railing/wood{
+	dir = 8
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/outdoors/town)
 "iuY" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/tavern)
-"iwe" = (
-/obj/structure/closet/crate/drawer,
-/obj/item/clothing/suit/roguetown/shirt/robe/necra{
-	name = "dark luxury robe"
-	},
-/obj/item/clothing/shoes/roguetown/sandals,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
 "iwo" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -4581,7 +4511,7 @@
 	pixel_x = 8
 	},
 /turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "iwv" = (
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/woods)
@@ -4590,13 +4520,13 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/snow,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "iyx" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "izp" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/roguegrass,
@@ -4617,7 +4547,7 @@
 "iBc" = (
 /obj/effect/landmark/start/blacksmith,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "iBK" = (
 /obj/structure/table/wood{
 	icon_state = "longtable";
@@ -4635,7 +4565,7 @@
 	pixel_x = 6
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "iCx" = (
 /obj/structure/bed/rogue/inn/double,
 /obj/item/bedsheet/rogue/double_pelt,
@@ -4666,7 +4596,7 @@
 "iFe" = (
 /mob/living/simple_animal/bird,
 /turf/open/floor/rogue/rooftop,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "iFl" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/fluff/railing/wood{
@@ -4676,13 +4606,13 @@
 	pixel_y = 7
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "iFP" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "iFR" = (
 /obj/structure/roguerock,
 /turf/open/floor/rogue/snow,
@@ -4706,34 +4636,27 @@
 	pixel_x = 5
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "iGv" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "iGX" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "iHC" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "iIt" = (
-/obj/structure/stairs{
-	icon_state = "stairs";
-	dir = 4
-	},
-/obj/structure/fluff/railing/wood{
-	pixel_x = 1;
-	pixel_y = -8
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town)
 "iJp" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -4741,7 +4664,7 @@
 	},
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "iLF" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -4749,7 +4672,7 @@
 /obj/structure/closet/crate/chest/old_crate,
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "iMF" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/rogue/blocks,
@@ -4759,11 +4682,9 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
 "iNO" = (
-/obj/structure/mineral_door/wood{
-	lockid = "house6"
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/obj/machinery/anvil,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town)
 "iPj" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -4783,10 +4704,15 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "iPW" = (
-/turf/closed/wall/mineral/rogue/decowood,
-/area/rogue/indoors)
+/obj/structure/flora/roguetree/snow{
+	icon_state = "tree2"
+	},
+/turf/open/floor/rogue/snow{
+	color = "e6f2ff"
+	},
+/area/rogue/outdoors/town)
 "iQG" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -4802,7 +4728,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "iSl" = (
 /obj/structure/closet/dirthole/closed/loot,
 /turf/open/floor/rogue/dirt/road,
@@ -4813,34 +4739,34 @@
 	lockid = "flints"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "iSL" = (
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "iTH" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
 	},
 /turf/open/floor/rogue/herringbone,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "iTK" = (
 /obj/structure/mineral_door/wood/towner/anyone,
 /turf/open/floor/rogue/carpet,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "iUi" = (
 /obj/structure/closet/crate/roguecloset/inn/south,
 /turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "iUV" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "iVc" = (
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "iVy" = (
 /obj/effect/spawner/roguemap/stump,
 /turf/open/floor/rogue/grasscold,
@@ -4856,7 +4782,7 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "iXp" = (
 /obj/structure/bed/rogue/inn,
 /obj/item/bedsheet/rogue/pelt,
@@ -4876,9 +4802,11 @@
 /turf/closed/mineral/random/rogue,
 /area/rogue/under/cave)
 "iXK" = (
-/obj/machinery/light/rogue/hearth,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/obj/structure/flora/bush,
+/turf/open/floor/rogue/snow{
+	color = "e6f2ff"
+	},
+/area/rogue/outdoors/town)
 "iXP" = (
 /obj/structure/fluff/railing/border,
 /turf/open/transparent/openspace,
@@ -4887,12 +4815,6 @@
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church)
-"iZM" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
 "jaj" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/dirt,
@@ -4902,7 +4824,7 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "jao" = (
 /obj/item/rogueweapon/pick,
 /obj/structure/rack/rogue,
@@ -4915,7 +4837,7 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "jcL" = (
 /obj/structure/spacevine,
 /turf/open/floor/rogue/grasscold,
@@ -4941,18 +4863,18 @@
 	},
 /obj/structure/closet/crate/chest/crate,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "jem" = (
 /obj/structure/composter,
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "jfy" = (
 /obj/structure/stairs{
 	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "jfX" = (
 /obj/structure/closet/crate/chest/neu_iron,
 /turf/open/floor/rogue/naturalstone,
@@ -4968,7 +4890,7 @@
 /obj/structure/fluff/railing/wood,
 /obj/structure/fermenting_barrel/water,
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "jkn" = (
 /obj/machinery/light/rogue/torchholder{
 	icon_state = "torchwall1";
@@ -4981,11 +4903,10 @@
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "jmN" = (
-/obj/machinery/light/rogue/cauldron,
-/turf/open/floor/rogue/wood,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town)
 "jmO" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -5003,7 +4924,7 @@
 "joV" = (
 /obj/effect/spawner/roguemap/stump,
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "jpG" = (
 /obj/structure/fluff/psycross,
 /obj/item/rogueweapon/woodstaff/aries,
@@ -5017,13 +4938,18 @@
 "jrj" = (
 /obj/structure/chair/wood/rogue/chair3,
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "jrz" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
 "jrE" = (
-/turf/closed/wall/mineral/rogue/decostone,
-/area/rogue/outdoors/mountains)
+/obj/structure/flora/roguetree/snow{
+	icon_state = "tree5"
+	},
+/turf/open/floor/rogue/snow{
+	color = "e6f2ff"
+	},
+/area/rogue/outdoors/town)
 "jsA" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/naturalstone,
@@ -5046,14 +4972,14 @@
 	},
 /obj/item/clothing/mask/cigarette/pipe,
 /turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "jwu" = (
 /obj/structure/closet/crate/drawer/inn,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "jwv" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "jwA" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -5062,10 +4988,7 @@
 	dir = 9
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
-"jwC" = (
-/turf/open/floor/carpet/red,
-/area/rogue/indoors)
+/area/rogue/outdoors/town)
 "jwP" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -5077,13 +5000,13 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "jxZ" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
 	},
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "jyC" = (
 /obj/structure/flora/roguegrass/thorn_bush,
 /turf/open/floor/rogue/dirt,
@@ -5131,7 +5054,7 @@
 "jCB" = (
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "jDE" = (
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church)
@@ -5149,11 +5072,7 @@
 	dir = 4
 	},
 /turf/open/water/bath,
-/area/rogue/indoors/town/bath)
-"jGz" = (
-/obj/effect/decal/cobbleedge,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town/church)
 "jHg" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -5161,10 +5080,13 @@
 	},
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "jHG" = (
-/turf/closed/mineral/random/rogue/med,
-/area/rogue)
+/obj/structure/flora/roguetree/snow{
+	icon_state = "tree2"
+	},
+/turf/open/floor/rogue/snow,
+/area/rogue/outdoors/town)
 "jIj" = (
 /obj/structure/spacevine,
 /turf/open/water/pond{
@@ -5175,11 +5097,11 @@
 "jIC" = (
 /obj/structure/roguemachine/stockpile,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "jII" = (
 /obj/structure/table/wood,
 /turf/open/floor/rogue/carpet,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "jKe" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/beach)
@@ -5194,7 +5116,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "jLQ" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/saiga/saigabuck,
 /turf/open/floor/rogue/snow,
@@ -5208,7 +5130,7 @@
 /turf/open/floor/rogue/snow{
 	color = "e6f2ff"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "jMP" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/dirt,
@@ -5224,7 +5146,7 @@
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "jPw" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/dirt/road,
@@ -5233,11 +5155,11 @@
 /obj/structure/table/wood,
 /obj/item/rogueweapon/huntingknife/chefknife,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "jPW" = (
 /turf/open/transparent/openspace,
 /turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "jRf" = (
 /obj/structure/bed/rogue/shit{
 	name = "makeshift bed"
@@ -5248,34 +5170,20 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "jSD" = (
-/obj/structure/closet/crate/chest/wicker,
-/obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
-	dir = 8
-	},
-/obj/item/natural/bundle/stick{
-	amount = 10
-	},
-/obj/item/natural/bundle/stick{
-	amount = 10
-	},
-/obj/item/natural/bundle/stick{
-	amount = 10
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/town)
 "jSH" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "jTm" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/rogue/grasscold,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "jVy" = (
 /obj/structure/stairs{
 	icon_state = "stairs";
@@ -5286,13 +5194,13 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "jYa" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/cooking/pan,
 /obj/machinery/light/rogue/oven/east,
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "jYt" = (
 /obj/structure/roguemachine/atm,
 /turf/open/floor/rogue/churchmarble,
@@ -5310,7 +5218,7 @@
 "kal" = (
 /obj/item/rogueweapon/hoe,
 /turf/open/floor/rogue/dirt,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "kaT" = (
 /obj/structure/fluff/railing/border{
 	pixel_y = -6
@@ -5322,11 +5230,11 @@
 	},
 /obj/structure/fluff/dryingrack,
 /turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "kaW" = (
 /obj/structure/fluff/grindwheel,
 /turf/open/floor/rogue/grasscold,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "kbJ" = (
 /obj/structure/fluff/dryingrack,
 /turf/open/floor/rogue/naturalstone,
@@ -5340,20 +5248,20 @@
 "kcg" = (
 /obj/machinery/anvil,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "kcM" = (
 /obj/structure/bookcase,
 /turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/under/cave)
+/area/rogue/indoors/town)
 "kcN" = (
 /obj/structure/closet/crate/roguecloset/inn,
 /turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "kdr" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/structure/fluff/psycross,
 /turf/open/floor/rogue/snow,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "kdK" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/church)
@@ -5384,7 +5292,7 @@
 "kgO" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "khc" = (
 /obj/structure/closet/crate/chest,
 /obj/item/natural/cloth,
@@ -5407,7 +5315,7 @@
 /obj/item/kitchen/spoon,
 /obj/item/kitchen/spoon,
 /turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "khH" = (
 /obj/machinery/light/rogue/hearth,
 /obj/machinery/light/rogue/oven{
@@ -5415,7 +5323,7 @@
 	},
 /obj/item/cooking/pan,
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "khL" = (
 /obj/structure/spacevine,
 /turf/open/floor/rogue/dirt/road,
@@ -5424,7 +5332,7 @@
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/cloth,
 /turf/open/floor/carpet/red,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "kiW" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -5434,7 +5342,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "kjj" = (
 /turf/open/water/bath,
 /area/rogue/outdoors/exposed/bath)
@@ -5457,7 +5365,7 @@
 	dir = 8
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "kny" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/saiga/saigabuck,
 /turf/open/floor/rogue/grasscold,
@@ -5469,35 +5377,37 @@
 	pixel_x = 6
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "koU" = (
 /obj/structure/flora/roguegrass/bush,
 /turf/open/floor/rogue/grasscold,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "kqj" = (
-/obj/structure/roguewindow,
-/turf/open/floor/rogue/twig,
-/area/rogue/outdoors/rtfield)
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/town)
 "kqp" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	locked = 1
 	},
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "krb" = (
 /obj/machinery/light/rogue/torchholder{
 	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "ksM" = (
 /obj/structure/spacevine,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cave)
 "ktr" = (
-/turf/closed/mineral/random/rogue,
-/area/rogue)
+/turf/open/floor/rogue/rooftop{
+	dir = 1;
+	icon_state = "roofg"
+	},
+/area/rogue/outdoors/town)
 "kul" = (
 /obj/structure/rack/rogue/shelf/big,
 /obj/item/broom{
@@ -5514,28 +5424,24 @@
 /obj/item/roguemachine/mastermail,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"kvF" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/outdoors/rtfield)
 "kvK" = (
 /mob/living/simple_animal/bird,
 /turf/open/floor/rogue/twig/platform,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "kwg" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/grasscold,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "kwz" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "kyp" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "kzb" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/hexstone,
@@ -5544,17 +5450,18 @@
 /obj/structure/flora/newtree,
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grasscold,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "kzw" = (
 /turf/open/floor/carpet/royalblack,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "kzR" = (
 /obj/structure/flora/roguetree/stump/log,
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/woods)
 "kzW" = (
-/turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town)
 "kAl" = (
 /obj/effect/decal/mossy{
 	dir = 8
@@ -5563,13 +5470,7 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
-"kAA" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "kBw" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4
@@ -5579,7 +5480,7 @@
 "kBJ" = (
 /obj/structure/closet/crate/roguecloset/inn/south,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "kBZ" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/wood/nosmooth,
@@ -5600,7 +5501,7 @@
 "kEx" = (
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "kEG" = (
 /obj/structure/flora/roguegrass/bush/wall,
 /obj/structure/fluff/railing/fence{
@@ -5608,7 +5509,7 @@
 	dir = 8
 	},
 /turf/open/floor/rogue/grasscold,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "kFF" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grasscold,
@@ -5622,7 +5523,7 @@
 	pixel_x = -8
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "kFR" = (
 /obj/effect/decal/cleanable/blood/gibs/torso,
 /obj/effect/decal/cleanable/blood/gibs/core,
@@ -5648,14 +5549,14 @@
 	dir = 8
 	},
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "kGa" = (
 /obj/structure/stairs{
 	icon_state = "stairs";
 	dir = 8
 	},
 /turf/open/floor/rogue/wood/herringbone,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "kHj" = (
 /obj/item/grown/log/tree/stake,
 /obj/structure/spacevine,
@@ -5671,7 +5572,7 @@
 	pixel_y = -8
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "kIY" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /turf/open/floor/rogue/hexstone,
@@ -5685,15 +5586,14 @@
 /area/rogue/outdoors/rtfield)
 "kJH" = (
 /turf/closed/wall/mineral/rogue/tent,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "kKS" = (
 /obj/structure/flora/roguetree,
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/mountains)
 "kLj" = (
-/obj/structure/mineral_door/wood,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/turf/closed/wall/mineral/rogue/decostone,
+/area/rogue/indoors/town/garrison)
 "kLI" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -5702,21 +5602,13 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
 "kLK" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/structure/rack/rogue/shelf,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/hay,
+/area/rogue/indoors/town)
 "kNe" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "kNz" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/thresher,
@@ -5727,7 +5619,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "kNS" = (
 /obj/structure/stairs{
 	dir = 8
@@ -5751,7 +5643,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "kRD" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/rogue/piedough,
@@ -5785,12 +5677,12 @@
 	pixel_y = 26
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "kSI" = (
-/obj/structure/fermenting_barrel/random/beer,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/turf/open/water/river{
+	icon_state = "rockwd"
+	},
+/area/rogue/outdoors/town)
 "kTf" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -5809,32 +5701,36 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/woods)
 "kUM" = (
-/obj/structure/stairs{
-	icon_state = "stairs";
-	dir = 1
+/obj/structure/flora/roguetree/snow{
+	icon_state = "tree11"
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/snow{
+	color = "e6f2ff"
+	},
+/area/rogue/outdoors/town)
 "kUT" = (
-/turf/open/floor/rogue/twig/platform,
-/area/rogue/outdoors/rtfield)
+/obj/structure/flora/roguetree/snow{
+	icon_state = "tree7"
+	},
+/turf/open/floor/rogue/snow,
+/area/rogue/outdoors/town)
 "kUZ" = (
 /turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "kWL" = (
 /turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "kWQ" = (
 /obj/structure/stairs{
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "kWX" = (
 /obj/structure/closet/crate/chest/crate,
 /obj/item/storage/roguebag,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "kXt" = (
 /obj/vehicle/ridden/lavaboat{
 	dir = 2;
@@ -5851,7 +5747,7 @@
 	pixel_y = 13
 	},
 /turf/open/floor/rogue/snow,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "laT" = (
 /obj/machinery/loom,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -5866,17 +5762,17 @@
 "ldA" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "leI" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "leP" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_y = 32
 	},
 /turf/open/water/bath,
-/area/rogue/indoors/town/bath)
+/area/rogue/indoors/town/church)
 "lfj" = (
 /obj/structure/spacevine,
 /turf/open/floor/rogue/dirt/road,
@@ -5900,15 +5796,15 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "lgQ" = (
 /obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "lhk" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/carpet,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "lhz" = (
 /obj/structure/flora/newbranch/leafless{
 	dir = 8
@@ -5916,9 +5812,8 @@
 /turf/open/floor/rogue/grasscold,
 /area/rogue/indoors/town/tavern)
 "ljo" = (
-/obj/machinery/light/rogue/hearth,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town)
 "ljR" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/wood,
@@ -5926,12 +5821,12 @@
 "lkx" = (
 /obj/effect/landmark/start/armorsmith,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "lkN" = (
 /obj/structure/bed/rogue/inn/double,
 /obj/item/bedsheet/rogue/double_pelt,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "llJ" = (
 /obj/structure/spacevine,
 /turf/open/floor/rogue/grasscold,
@@ -5939,7 +5834,7 @@
 "llL" = (
 /obj/machinery/light/rogue/chand,
 /turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "lnn" = (
 /turf/open/floor/rogue/snow,
 /area/rogue/outdoors/rtfield)
@@ -5953,7 +5848,7 @@
 	color = "e6f2ff"
 	},
 /turf/open/floor/rogue/snow,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "low" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -5966,7 +5861,7 @@
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "loN" = (
 /obj/structure/flora/roguetree/snow{
 	icon_state = "tree7"
@@ -5978,7 +5873,7 @@
 "lpd" = (
 /obj/machinery/light/rogue/campfire,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/woods)
 "lpq" = (
 /obj/effect/decal/remains/wolf,
 /turf/open/floor/rogue/dirt,
@@ -5988,7 +5883,7 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "lpL" = (
 /obj/structure/closet/dirthole/grave,
 /obj/structure/flora/roguegrass/water,
@@ -6011,24 +5906,22 @@
 	dir = 5
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "lrV" = (
 /obj/structure/bookcase/random/archive,
 /obj/item/reagent_containers/glass/bottle/rogue/manapot,
 /obj/item/reagent_containers/glass/bottle/rogue/manapot,
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "lsd" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "lsY" = (
-/obj/machinery/light/rogue/torchholder{
-	pixel_y = 26
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/obj/structure/flora/bush,
+/turf/open/floor/rogue/snow,
+/area/rogue/outdoors/town)
 "lty" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -6037,7 +5930,7 @@
 /turf/open/floor/rogue/snow{
 	color = "e6f2ff"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "ltM" = (
 /obj/structure/fluff/customsign{
 	name = "sign - Trading bay";
@@ -6050,7 +5943,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "lvL" = (
 /obj/machinery/light/rogue/torchholder/l,
 /obj/structure/fluff/railing/wood{
@@ -6066,7 +5959,7 @@
 	pixel_x = 6
 	},
 /turf/open/transparent/openspace,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "lwh" = (
 /obj/structure/bed/rogue/inn/double,
 /obj/item/bedsheet/rogue/double_pelt,
@@ -6090,7 +5983,7 @@
 "lwR" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "lxn" = (
 /obj/structure/stairs/stone,
 /obj/structure/fluff/railing/border{
@@ -6099,18 +5992,19 @@
 	pixel_x = 6
 	},
 /turf/open/floor/rogue/blocks/platform,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "lyP" = (
-/obj/structure/roguetent,
-/turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/turf/closed/wall/mineral/rogue/wood,
+/area/rogue/outdoors/town)
 "lyQ" = (
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/rtfield)
 "lzU" = (
-/obj/structure/mineral_door/wood,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/snow{
+	color = "e6f2ff"
+	},
+/area/rogue/outdoors/town)
 "lAc" = (
 /obj/structure/flora/roguegrass/swampweed,
 /turf/open/floor/rogue/dirt/road,
@@ -6124,7 +6018,7 @@
 	dir = 8
 	},
 /turf/open/water/cleanshallow,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "lAJ" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/wood/herringbone,
@@ -6137,12 +6031,13 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church)
 "lAV" = (
-/turf/open/floor/rogue/naturalstone,
-/area/rogue)
+/obj/structure/flora/roguegrass/bush/wall,
+/turf/open/floor/rogue/grasscold,
+/area/rogue/outdoors/town)
 "lBl" = (
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/carpet/royalblack,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "lCz" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -6159,31 +6054,31 @@
 /turf/open/floor/rogue/snow{
 	color = "e6f2ff"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "lFU" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
 	},
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "lGa" = (
 /obj/structure/bed/rogue/inn/double,
 /obj/item/bedsheet/rogue/double_pelt,
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "lHP" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "lHX" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
 	},
 /turf/open/floor/carpet/red,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "lIw" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -6199,21 +6094,21 @@
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow,
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow,
 /turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "lJv" = (
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "lLr" = (
 /obj/structure/stairs,
 /turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "lMi" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
 	},
 /turf/open/floor/rogue/blocks/platform,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "lNu" = (
 /obj/structure/flora/roguetree/snow{
 	icon_state = "tree3"
@@ -6222,7 +6117,7 @@
 	icon_state = "rockwd";
 	dir = 1
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "lNx" = (
 /obj/machinery/light/rogue/torchholder{
 	icon_state = "torchwall1";
@@ -6235,11 +6130,11 @@
 /turf/open/floor/rogue/snow{
 	color = "e6f2ff"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "lOh" = (
 /obj/machinery/light/rogue/oven/north,
 /turf/closed/wall/mineral/rogue/wooddark,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "lOq" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/rogue/naturalstone,
@@ -6250,11 +6145,11 @@
 /area/rogue/outdoors/mountains)
 "lRw" = (
 /turf/closed/wall/mineral/rogue/stone,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "lRI" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/grasscold,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "lRY" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -6279,24 +6174,21 @@
 	dir = 8
 	},
 /turf/open/water/bath,
-/area/rogue/indoors/town/bath)
+/area/rogue/indoors/town/church)
 "lUQ" = (
 /obj/structure/roguewindow/openclose{
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "lUR" = (
 /obj/effect/decal/remains/saiga,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/woods)
 "lWc" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/rtfield)
+/obj/effect/spawner/roguemap/stump,
+/turf/open/floor/rogue/snow,
+/area/rogue/outdoors/town)
 "lWi" = (
 /obj/structure/flora/roguegrass/water,
 /turf/open/floor/rogue/dirt/road,
@@ -6306,36 +6198,35 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave)
 "lXU" = (
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors)
+/obj/structure/fluff/railing/wood{
+	pixel_x = 1;
+	pixel_y = -8
+	},
+/turf/open/transparent/openspace,
+/area/rogue/indoors/town/garrison)
 "lYA" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/beach)
 "lYH" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "lZm" = (
 /obj/machinery/light/rogue/hearth,
 /obj/machinery/light/rogue/oven/east,
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "mab" = (
 /obj/structure/flora/roguetree/snow{
 	icon_state = "tree3"
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "maz" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/natural/feather,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/indoors/town)
 "maL" = (
 /obj/machinery/light/rogue/torchholder/c{
 	pixel_y = -32
@@ -6353,17 +6244,17 @@
 "mcW" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "mdd" = (
 /obj/structure/fermenting_barrel/water,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "mdn" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "mec" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_y = 32
@@ -6375,7 +6266,7 @@
 	pixel_x = 2
 	},
 /turf/closed/wall/mineral/rogue/wood,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "meh" = (
 /obj/item/natural/rock,
 /turf/open/floor/rogue/dirt,
@@ -6389,19 +6280,19 @@
 	pixel_y = 8
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "mhc" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "mhz" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
 	pixel_y = -1
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "mji" = (
 /turf/open/lava,
 /area/rogue/under/cave)
@@ -6412,26 +6303,26 @@
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 1
 	},
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "mlz" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
 	},
 /turf/open/floor/rogue/twig/platform,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "mlT" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
 	},
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "mlW" = (
 /obj/structure/stairs{
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "mmm" = (
 /obj/structure/flora/newbranch{
 	dir = 1
@@ -6443,11 +6334,11 @@
 	icon_state = "tree7"
 	},
 /turf/open/water/cleanshallow,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "moC" = (
-/obj/structure/roguewindow/openclose,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/obj/machinery/light/rogue/firebowl/stump,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/town)
 "mpl" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -6456,15 +6347,15 @@
 	pixel_y = 7
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "mrM" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "mtb" = (
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "muq" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
@@ -6509,7 +6400,7 @@
 	pixel_y = 7
 	},
 /turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "mvK" = (
 /obj/structure/flora/roguetree/snow{
 	icon_state = "tree8"
@@ -6527,23 +6418,23 @@
 /obj/item/reagent_containers/glass/bowl,
 /obj/item/kitchen/rollingpin,
 /turf/open/floor/rogue/wood,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "mxw" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "mye" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "myk" = (
 /obj/structure/roguemachine/steward{
 	locked = 1
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "mzj" = (
 /obj/structure/closet/crate/chest/neu_fancy,
 /obj/item/roguecoin/gold/pile,
@@ -6560,7 +6451,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "mAA" = (
 /turf/open/water/river{
 	icon_state = "rockwd";
@@ -6570,17 +6461,17 @@
 "mAD" = (
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "mBN" = (
 /turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "mBT" = (
 /obj/structure/stairs{
 	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town/garrison)
 "mCL" = (
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/grasscold,
@@ -6590,7 +6481,7 @@
 	pixel_y = -6
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "mDa" = (
 /obj/structure/spacevine,
 /turf/open/transparent/openspace,
@@ -6610,7 +6501,7 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "mDw" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_y = 32
@@ -6619,16 +6510,16 @@
 /area/rogue/indoors/town/church)
 "mDW" = (
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "mEm" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/transparent/openspace,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "mEr" = (
 /obj/structure/closet/crate/drawer,
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/under/cave)
+/area/rogue/indoors/town)
 "mFL" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -6643,7 +6534,7 @@
 	pixel_x = 8
 	},
 /turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "mIn" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/naturalstone,
@@ -6682,7 +6573,7 @@
 /obj/item/reagent_containers/glass/bucket/pot,
 /obj/item/reagent_containers/glass/bucket/pot,
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "mLS" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/naturalstone,
@@ -6694,7 +6585,7 @@
 	},
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "mML" = (
 /obj/item/rogueweapon/huntingknife/stoneknife,
 /turf/open/floor/rogue/grasscold,
@@ -6714,7 +6605,7 @@
 /turf/open/floor/rogue/snow{
 	color = "e6f2ff"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "mPd" = (
 /obj/structure/underworld/barrier,
 /obj/structure/underworld/carriage_normal{
@@ -6732,7 +6623,7 @@
 	icon_state = "tree5"
 	},
 /turf/open/water/cleanshallow,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "mRc" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -6741,18 +6632,18 @@
 	},
 /obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "mRr" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
 "mSv" = (
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "mUd" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/herringbone,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "mUx" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -6769,7 +6660,7 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "mUR" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -6777,7 +6668,7 @@
 	pixel_x = 6
 	},
 /turf/open/floor/rogue/twig/platform,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "mVe" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
@@ -6786,14 +6677,14 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/wood/herringbone,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "mVu" = (
 /obj/structure/stairs{
 	icon_state = "stairs";
 	dir = 8
 	},
 /turf/open/water/swamp,
-/area/rogue/under/cave)
+/area/rogue/indoors/town)
 "mVI" = (
 /obj/machinery/light/rogue/torchholder{
 	icon_state = "torchwall1";
@@ -6818,7 +6709,7 @@
 /obj/item/customblank,
 /obj/item/customblank,
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "mZU" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -6833,7 +6724,7 @@
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "naq" = (
 /turf/open/water/river{
 	icon_state = "rockwd";
@@ -6844,7 +6735,7 @@
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 8
 	},
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "ncZ" = (
 /obj/structure/flora/newbranch/connector{
 	dir = 4
@@ -6871,16 +6762,16 @@
 	},
 /obj/structure/bars/passage/shutter/open,
 /turf/open/floor/rogue/wood/herringbone,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "ngx" = (
 /obj/structure/roguewindow/openclose{
 	dir = 8
 	},
 /turf/open/floor/rogue/herringbone,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "ngE" = (
 /turf/open/floor/rogue/grass,
-/area/rogue/outdoors/woods)
+/area/rogue/outdoors/town)
 "ngL" = (
 /obj/machinery/light/rogue/torchholder{
 	icon_state = "torchwall1";
@@ -6888,14 +6779,14 @@
 	},
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/herringbone,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "ngR" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
 	pixel_y = -1
 	},
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "nho" = (
 /obj/structure/stairs{
 	icon_state = "stairs";
@@ -6924,7 +6815,7 @@
 /obj/item/kitchen/fork,
 /obj/item/kitchen/fork,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "nlq" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/naturalstone,
@@ -6955,7 +6846,7 @@
 	pixel_y = 26
 	},
 /turf/open/floor/rogue/blocks/platform,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "nqu" = (
 /obj/structure/fluff/railing/border,
 /turf/open/transparent/openspace,
@@ -6968,12 +6859,12 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "nqR" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/cobble,
-/area/rogue/under/cave)
+/area/rogue/indoors/town)
 "nsc" = (
 /obj/structure/spacevine,
 /turf/open/floor/rogue/naturalstone,
@@ -6986,7 +6877,7 @@
 	},
 /obj/structure/chair/wood/rogue/chair3,
 /turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "ntv" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors/town/vault)
@@ -7000,7 +6891,7 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "nww" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -7034,7 +6925,7 @@
 /obj/item/quiver/arrows,
 /obj/item/quiver/arrows,
 /turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "nyn" = (
 /obj/structure/table/wood,
 /obj/item/roguekey/custom{
@@ -7042,7 +6933,7 @@
 	lockid = "flints"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "nAg" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/twig,
@@ -7052,7 +6943,7 @@
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "nAs" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/naturalstone,
@@ -7064,19 +6955,14 @@
 /obj/effect/landmark/start/servant,
 /obj/structure/roguemachine/stockpile,
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "nBF" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/bull,
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "nCA" = (
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 8
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "nFu" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -7088,7 +6974,7 @@
 	pixel_y = -8
 	},
 /turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "nFv" = (
 /obj/structure/fluff/alch,
 /turf/open/floor/rogue/hexstone,
@@ -7104,7 +6990,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "nMa" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/transparent/openspace,
@@ -7119,7 +7005,7 @@
 	pixel_y = 14
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "nNk" = (
 /obj/machinery/light/rogue/torchholder{
 	icon_state = "torchwall1";
@@ -7137,7 +7023,7 @@
 /obj/item/rogueweapon/shovel/small,
 /obj/item/grown/log/tree/stake,
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "nPK" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt/road,
@@ -7149,13 +7035,13 @@
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "nQr" = (
 /obj/structure/fluff/walldeco/innsign{
 	name = "sign - resting area below"
 	},
 /turf/closed/wall/mineral/rogue/tent,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "nQu" = (
 /obj/structure/spacevine,
 /turf/open/water/river{
@@ -7168,7 +7054,7 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/snow,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "nTR" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -7193,7 +7079,7 @@
 	pixel_x = 8
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "nXc" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf{
 	dir = 8
@@ -7219,7 +7105,7 @@
 /obj/item/book/rogue/tales3,
 /obj/item/book/rogue/nitebeast,
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "odi" = (
 /obj/structure/far_travel,
 /turf/open/floor/rogue/cobblerock,
@@ -7235,7 +7121,7 @@
 	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "odW" = (
 /obj/structure/fluff/railing/border{
 	dir = 1;
@@ -7250,7 +7136,7 @@
 	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "ogi" = (
 /turf/open/water/ocean{
 	name = "river water";
@@ -7271,31 +7157,15 @@
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "oiN" = (
 /obj/effect/decal/mossy,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "olP" = (
-/obj/effect/decal/cobbleedge{
-	dir = 6
-	},
-/obj/structure/rack/rogue/shelf/biggest,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/kitchen/spoon,
-/obj/item/kitchen/spoon,
-/obj/item/kitchen/spoon,
-/obj/item/kitchen/spoon,
-/obj/item/kitchen/spoon,
+/obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town/garrison)
 "omo" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/snow{
@@ -7310,7 +7180,7 @@
 	dir = 8
 	},
 /turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "ooe" = (
 /obj/structure/spacevine,
 /turf/closed/wall/mineral/rogue/stone/moss,
@@ -7326,7 +7196,7 @@
 "ooG" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "opb" = (
 /obj/structure/flora/roguetree/snow{
 	icon_state = "tree11"
@@ -7339,13 +7209,13 @@
 	dir = 8
 	},
 /turf/open/floor/rogue/hay,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "opX" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblack,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "orD" = (
 /obj/effect/landmark/start/adventurerlate{
 	icon_state = "arrow";
@@ -7381,7 +7251,7 @@
 "owU" = (
 /obj/structure/mineral_door/wood/towner/anyone,
 /turf/open/floor/rogue/wood,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "oyy" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/table/wood{
@@ -7427,14 +7297,14 @@
 	},
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "oCY" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
 	},
 /obj/structure/closet/crate/chest/crate,
 /turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "oDG" = (
 /obj/structure/roguerock,
 /turf/open/floor/rogue/dirt/road,
@@ -7444,7 +7314,7 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "oFx" = (
 /obj/item/natural/rock,
 /turf/open/floor/rogue/dirt/road,
@@ -7453,10 +7323,10 @@
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 1
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "oHl" = (
 /turf/closed/wall/mineral/rogue/decowood/vert,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "oHP" = (
 /obj/item/pestle,
 /obj/structure/table/wood{
@@ -7464,7 +7334,7 @@
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "oIy" = (
 /obj/structure/flora/roguetree/snow{
 	icon_state = "tree4"
@@ -7475,29 +7345,27 @@
 /obj/structure/fluff/railing/border,
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "oIG" = (
 /obj/structure/spacevine,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/woods)
 "oIO" = (
-/obj/structure/closet/crate/drawer,
-/obj/item/clothing/suit/roguetown/shirt/robe/necra{
-	name = "dark luxury robe"
+/obj/structure/flora/roguetree/snow{
+	icon_state = "tree3"
 	},
-/obj/item/clothing/shoes/roguetown/sandals,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/grasscold,
+/area/rogue/outdoors/town)
 "oJU" = (
 /obj/structure/mineral_door/wood/towner/blacksmith,
 /turf/open/floor/rogue/herringbone,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "oLN" = (
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church)
 "oLW" = (
 /turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "oMx" = (
 /obj/structure/flora/bush,
 /turf/open/floor/rogue/dirt/road,
@@ -7514,14 +7382,14 @@
 "oNP" = (
 /obj/structure/bed/rogue/bedroll,
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "oNT" = (
 /obj/structure/stairs{
 	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "oOu" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -7530,7 +7398,7 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "oOL" = (
 /obj/structure/flora/newbranch/connector{
 	dir = 8
@@ -7542,14 +7410,14 @@
 	pixel_y = -32
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "oPb" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
 	pixel_y = -1
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "oPE" = (
 /obj/structure/flora/roguetree/normal,
 /turf/open/floor/rogue/grasscold,
@@ -7561,7 +7429,7 @@
 /turf/open/floor/rogue/snow{
 	color = "e6f2ff"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "oSE" = (
 /obj/structure/spacevine,
 /turf/open/floor/rogue/dirt,
@@ -7588,7 +7456,7 @@
 	},
 /obj/structure/bee,
 /turf/open/floor/rogue/hay,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "oVz" = (
 /obj/structure/fluff/railing/fence,
 /obj/machinery/light/rogue/wallfire/candle/r,
@@ -7598,13 +7466,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/chair/stool/bar/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "oWz" = (
 /turf/open/water/pond{
 	name = "hotspring";
 	desc = "Still and idyllic hot water that flows through meadows."
 	},
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "oWG" = (
 /obj/structure/flora/roguetree/snow{
 	pixel_x = -28
@@ -7621,27 +7489,12 @@
 /obj/item/natural/rock,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cave)
-"pad" = (
-/obj/structure/fluff/railing/wood{
-	pixel_x = 1;
-	pixel_y = -8
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 4;
-	layer = 2.8;
-	pixel_x = 8
-	},
-/obj/structure/bookcase,
-/obj/item/book/rogue/tales3,
-/obj/item/book/rogue/knowledge1,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
 "paF" = (
 /obj/structure/chair/wood/rogue{
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "paM" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/twig,
@@ -7692,17 +7545,17 @@
 "pha" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "phd" = (
 /obj/item/roguebin,
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "phy" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1
 	},
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "phC" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -7716,11 +7569,11 @@
 	pixel_x = 8
 	},
 /turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "piD" = (
 /obj/structure/roguerock,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "piO" = (
 /obj/structure/bed/rogue/inn/hay,
 /turf/open/floor/rogue/hexstone,
@@ -7745,7 +7598,7 @@
 	},
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "pkN" = (
 /obj/effect/landmark/mapGenerator/sunlights{
 	endTurfX = 155;
@@ -7756,7 +7609,7 @@
 "pnc" = (
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/grasscold,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "pnf" = (
 /mob/living/simple_animal/pet/cat/black{
 	name = "Lily"
@@ -7774,7 +7627,7 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/red,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "pof" = (
 /obj/structure/closet/crate/roguecloset/inn/south,
 /turf/open/floor/rogue/wood,
@@ -7792,7 +7645,7 @@
 /obj/item/paper,
 /obj/item/natural/feather,
 /turf/open/floor/carpet/royalblack,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "ppp" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/cobblerock,
@@ -7803,7 +7656,7 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/snow,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "pqB" = (
 /obj/machinery/light/rogue/oven/south,
 /obj/structure/table/wood{
@@ -7814,7 +7667,7 @@
 "pqD" = (
 /obj/structure/fluff/alch,
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "prh" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -7822,11 +7675,11 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "prk" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/dirt,
-/area/rogue/under/cave)
+/area/rogue/under/town)
 "prp" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cave)
@@ -7837,25 +7690,25 @@
 /turf/open/floor/rogue/snow{
 	color = "e6f2ff"
 	},
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "psv" = (
 /obj/machinery/light/rogue/campfire/densefire{
 	pixel_y = 3;
 	pixel_x = 1
 	},
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "ptg" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
 	},
 /obj/item/customlock,
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "ptM" = (
 /obj/effect/decal/mossy,
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "ptV" = (
 /obj/structure/closet/crate/chest/neu_fancy,
 /obj/item/roguecoin/silver/pile,
@@ -7867,11 +7720,11 @@
 /obj/structure/bed/rogue/inn/double,
 /obj/item/bedsheet/rogue/double_pelt,
 /turf/open/floor/rogue/carpet,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "pub" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "puc" = (
 /obj/structure/fluff/railing/wood{
 	pixel_x = 1;
@@ -7891,10 +7744,10 @@
 	dir = 8
 	},
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "puh" = (
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/indoors)
+/area/rogue/outdoors/town)
 "pun" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/blocks,
@@ -7902,7 +7755,7 @@
 "puV" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "pvN" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/mudcrab{
 	dir = 1
@@ -7928,7 +7781,7 @@
 	},
 /obj/item/roguegear,
 /turf/open/floor/rogue/wood/herringbone,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "pzu" = (
 /obj/structure/closet/crate/chest/old_crate,
 /obj/item/reagent_containers/glass/cup/wooden,
@@ -7944,7 +7797,7 @@
 /obj/item/kitchen/spoon,
 /obj/item/kitchen/spoon,
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "pAw" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -7964,16 +7817,16 @@
 /obj/item/kitchen/spoon,
 /obj/item/kitchen/spoon,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "pBT" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/bath)
+/area/rogue/indoors/town/church)
 "pCg" = (
 /obj/structure/fluff/railing/wood,
 /obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "pCI" = (
 /obj/effect/decal/remains/wolf,
 /obj/effect/decal/cleanable/blood/gibs,
@@ -7983,7 +7836,7 @@
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 5
 	},
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "pDl" = (
 /obj/structure/fluff/railing/border{
 	dir = 1;
@@ -7994,7 +7847,7 @@
 "pFm" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/grasscold,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "pFB" = (
 /obj/structure/fluff/railing/border,
 /obj/machinery/light/rogue/wallfire/candle{
@@ -8009,7 +7862,7 @@
 	dir = 8
 	},
 /turf/open/transparent/openspace,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "pHC" = (
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/snow{
@@ -8019,14 +7872,14 @@
 "pIl" = (
 /obj/structure/globe,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "pIG" = (
 /obj/structure/fluff/railing/stonehedge{
 	dir = 4
 	},
 /obj/structure/fluff/railing/stonehedge,
 /turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "pJb" = (
 /obj/structure/mineral_door/wood/donjon/stone,
 /turf/open/floor/rogue/naturalstone,
@@ -8037,7 +7890,7 @@
 	},
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "pLn" = (
 /obj/structure/mineral_door/swing_door,
 /turf/open/floor/rogue/herringbone,
@@ -8071,13 +7924,13 @@
 "pOi" = (
 /obj/structure/bed/rogue/bedroll,
 /turf/open/floor/rogue/hay,
-/area/rogue)
+/area/rogue/outdoors/rtfield)
 "pOk" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church)
 "pOn" = (
-/turf/closed/wall/mineral/rogue/stone,
-/area/rogue/indoors/town/bath)
+/turf/open/floor/rogue/grasscold,
+/area/rogue/outdoors/town)
 "pOo" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -8095,7 +7948,7 @@
 "pON" = (
 /obj/structure/closet/crate/roguecloset/dark,
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "pQq" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -8105,11 +7958,13 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "pQw" = (
-/obj/structure/mineral_door/wood/deadbolt,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/obj/structure/flora/roguetree/snow{
+	icon_state = "tree11"
+	},
+/turf/open/floor/rogue/snow,
+/area/rogue/outdoors/town)
 "pQJ" = (
 /obj/machinery/gear_painter,
 /turf/open/floor/rogue/dirt,
@@ -8125,13 +7980,11 @@
 	pixel_x = -6
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "pRS" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 4
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors)
+/obj/structure/chair/wood/rogue/fancy,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town)
 "pSb" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/saiga/saigakid,
 /turf/open/floor/rogue/grasscold,
@@ -8142,23 +7995,25 @@
 	icon_state = "longtable"
 	},
 /turf/open/floor/carpet/red,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "pSx" = (
-/obj/structure/mineral_door/wood/towner/anyone,
-/turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/obj/structure/flora/roguetree/snow{
+	icon_state = "tree3"
+	},
+/turf/open/floor/rogue/snow,
+/area/rogue/outdoors/town)
 "pTo" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "pUe" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "pUo" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -8172,7 +8027,7 @@
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/carpet/red,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "pUW" = (
 /obj/structure/fluff/railing/wood,
 /obj/structure/table/wood{
@@ -8180,7 +8035,7 @@
 	},
 /obj/item/pestle,
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "pVd" = (
 /obj/structure/flora/roguetree/snow{
 	icon_state = "tree8"
@@ -8188,15 +8043,15 @@
 /turf/open/floor/rogue/snow{
 	color = "e6f2ff"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "pVi" = (
 /obj/structure/closet/crate/chest/crate,
 /turf/open/floor/rogue/wood,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "pWo" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/under/cave)
+/area/rogue/indoors/town)
 "pWt" = (
 /obj/structure/stairs{
 	dir = 8
@@ -8228,7 +8083,7 @@
 "pZF" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/under/cave)
+/area/rogue/indoors/town/garrison)
 "pZI" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -8257,7 +8112,7 @@
 /obj/item/storage/backpack/rogue/backpack,
 /obj/item/storage/backpack/rogue/backpack,
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "qfF" = (
 /obj/structure/flora/rogueshroom,
 /turf/open/floor/rogue/dirt/road,
@@ -8272,15 +8127,15 @@
 	dir = 10
 	},
 /turf/open/floor/rogue/blocks/platform,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "qgB" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/fermenting_barrel/hagwoodbitter,
 /turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/under/cave)
+/area/rogue/indoors/town)
 "qhe" = (
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/cave)
+/turf/open/floor/rogue/rooftop,
+/area/rogue/outdoors/town)
 "qij" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/structure/fluff/railing/wood{
@@ -8290,13 +8145,13 @@
 	pixel_y = 7
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "qje" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "qjj" = (
 /obj/item/gun/ballistic/arquebus_pistol,
 /obj/effect/decal/remains/human,
@@ -8321,11 +8176,11 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/herringbone,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "qky" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/transparent/openspace,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "qkW" = (
 /obj/structure/closet/crate/chest/wicker{
 	opened = 1
@@ -8335,7 +8190,7 @@
 "qla" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "qli" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/rogue/naturalstone,
@@ -8350,13 +8205,7 @@
 	},
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/transparent/openspace,
-/area/rogue/outdoors/rtfield)
-"qmy" = (
-/obj/machinery/light/rogue/wallfire{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "qmO" = (
 /obj/structure/flora/roguegrass/water,
 /turf/open/floor/rogue/naturalstone,
@@ -8374,13 +8223,13 @@
 	pixel_y = -8
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "qpT" = (
 /obj/structure/mineral_door/wood/violet{
 	keylock = 0
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "qqk" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -8417,7 +8266,7 @@
 	pixel_x = -6
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "quh" = (
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/dirt/road,
@@ -8441,7 +8290,7 @@
 	dir = 5
 	},
 /turf/open/floor/rogue/twig/platform,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "qwj" = (
 /obj/structure/flora/roguetree/snow{
 	icon_state = "tree2"
@@ -8457,7 +8306,7 @@
 	pixel_x = 8
 	},
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "qyk" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town)
@@ -8474,7 +8323,7 @@
 	dir = 5
 	},
 /turf/open/floor/rogue/twig,
-/area/rogue)
+/area/rogue/outdoors/town)
 "qzM" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -8485,7 +8334,7 @@
 	icon_state = "vertw";
 	dir = 1
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "qAl" = (
 /obj/structure/table/wood,
 /obj/machinery/light/rogue/wallfire/candle/r,
@@ -8498,7 +8347,7 @@
 "qAs" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/under/cave)
+/area/rogue/indoors/town/cell)
 "qBT" = (
 /obj/effect/decal/mossy,
 /obj/effect/decal/cobbleedge{
@@ -8506,14 +8355,14 @@
 	},
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "qCP" = (
 /obj/machinery/light/rogue/torchholder{
 	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/twig/platform,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "qEl" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf,
 /turf/open/floor/rogue/naturalstone,
@@ -8523,7 +8372,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "qGf" = (
 /obj/structure/flora/roguetree/stump/log,
 /turf/open/floor/rogue/dirt,
@@ -8537,7 +8386,7 @@
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "qGZ" = (
 /obj/item/rogueweapon/stoneaxe,
 /turf/open/floor/rogue/grasscold,
@@ -8548,7 +8397,7 @@
 "qIx" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "qJc" = (
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/rogue/dirt/road,
@@ -8559,15 +8408,15 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "qKM" = (
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "qLR" = (
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "qMW" = (
 /obj/structure/closet/crate/drawer,
 /obj/item/clothing/suit/roguetown/shirt/robe/necra{
@@ -8575,7 +8424,7 @@
 	},
 /obj/item/clothing/shoes/roguetown/sandals,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "qNu" = (
 /obj/item/natural/stone{
 	icon_state = "stone4"
@@ -8593,15 +8442,15 @@
 	dir = 8
 	},
 /turf/open/floor/rogue/grasscold,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "qRR" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "qSD" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/cow,
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "qSO" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/naturalstone,
@@ -8609,11 +8458,11 @@
 "qSS" = (
 /obj/structure/handcart,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "qTt" = (
 /obj/structure/closet/crate/drawer/inn,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "qUh" = (
 /obj/structure/fluff/railing/wood{
 	pixel_x = 1;
@@ -8658,17 +8507,17 @@
 	pixel_y = 18
 	},
 /turf/open/floor/carpet/royalblack,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "qVM" = (
 /obj/structure/ladder{
 	pixel_y = 18
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "qWh" = (
 /obj/machinery/light/rogue/campfire/densefire,
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "qWx" = (
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/bath)
@@ -8681,20 +8530,20 @@
 	dir = 6
 	},
 /turf/open/floor/rogue/blocks/platform,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "qXZ" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/wood,
-/area/rogue/outdoors/mountains)
+/obj/structure/flora/bush,
+/turf/open/floor/rogue/grasscold,
+/area/rogue/outdoors/town)
 "qYz" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "qYO" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood3"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/under/cave)
+/area/rogue/indoors/town/garrison)
 "qZE" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/blocks,
@@ -8706,11 +8555,11 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "ras" = (
 /obj/machinery/light/rogue/campfire/densefire,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "raN" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -8749,7 +8598,7 @@
 "rbz" = (
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "rcv" = (
 /turf/closed/mineral/random/rogue,
 /area/rogue/outdoors/mountains)
@@ -8764,10 +8613,10 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "rej" = (
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "req" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/floor/rogue/dirt/ambush,
@@ -8777,7 +8626,7 @@
 	pixel_y = 26
 	},
 /turf/open/floor/rogue/snow,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "rgX" = (
 /obj/structure/roguetent,
 /turf/open/floor/carpet/royalblack,
@@ -8787,7 +8636,7 @@
 	opened = 1
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "riD" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -8795,12 +8644,12 @@
 	},
 /obj/structure/beehive,
 /turf/open/floor/rogue/hay,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "riT" = (
 /obj/structure/bed/rogue/inn,
 /obj/item/bedsheet/rogue/cloth,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "riU" = (
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/naturalstone,
@@ -8814,7 +8663,7 @@
 	pixel_y = 0
 	},
 /turf/closed/wall/mineral/rogue/decowood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "rlL" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -8842,12 +8691,12 @@
 "rrv" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "rrK" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/stairs,
 /turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "rsd" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -8855,11 +8704,15 @@
 "rtr" = (
 /obj/structure/table/wood,
 /turf/open/floor/rogue/grasscold,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "rvZ" = (
-/obj/structure/stairs,
-/turf/open/floor/rogue/wood,
-/area/rogue/outdoors/mountains)
+/obj/structure/flora/roguetree/snow{
+	icon_state = "tree7"
+	},
+/turf/open/floor/rogue/snow{
+	color = "e6f2ff"
+	},
+/area/rogue/outdoors/town)
 "rwQ" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/snow{
@@ -8875,21 +8728,21 @@
 /turf/open/floor/rogue/snow{
 	color = "e6f2ff"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "rCp" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "rCA" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 1
 	},
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/herringbone,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "rCR" = (
 /turf/open/floor/rogue/rooftop/green,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "rCX" = (
 /obj/structure/rack/rogue/shelf/big,
 /obj/item/kitchen/spoon,
@@ -8915,7 +8768,7 @@
 	dir = 1
 	},
 /turf/open/transparent/openspace,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "rDg" = (
 /obj/structure/crabnest,
 /turf/open/floor/rogue/dirt/ambush,
@@ -8924,8 +8777,8 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cave)
 "rDz" = (
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/indoors/town/garrison)
 "rDL" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/cobblerock,
@@ -8935,7 +8788,7 @@
 	dir = 8
 	},
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "rDX" = (
 /obj/machinery/light/rogue/torchholder{
 	icon_state = "torchwall1";
@@ -8946,11 +8799,11 @@
 "rEe" = (
 /obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/woodturned,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "rFn" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/wood,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "rFP" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -8962,17 +8815,17 @@
 	pixel_x = 6
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "rGw" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/under/cave)
+/area/rogue/indoors/town/cell)
 "rGG" = (
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "rHC" = (
 /obj/structure/fermenting_barrel/water,
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -9000,7 +8853,7 @@
 "rIC" = (
 /obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "rJa" = (
 /turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/tavern)
@@ -9010,7 +8863,7 @@
 	layer = 2.7
 	},
 /turf/open/floor/rogue/hay,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "rJt" = (
 /obj/structure/bookcase,
 /obj/item/book/rogue/noc,
@@ -9018,31 +8871,22 @@
 /obj/item/book/rogue/beardling,
 /obj/item/book/rogue/arcyne,
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "rJC" = (
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/mountains)
-"rJG" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "rJM" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "rJY" = (
 /obj/structure/fluff/customsign{
 	name = "sign - Vineyard"
 	},
 /turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "rLu" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/blocks,
@@ -9057,7 +8901,7 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "rNp" = (
 /obj/structure/fluff/railing/fence{
 	icon_state = "fence";
@@ -9066,7 +8910,7 @@
 /turf/open/floor/rogue/snow{
 	color = "e6f2ff"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "rOV" = (
 /turf/closed/mineral/random/rogue/med,
 /area/rogue/outdoors/mountains)
@@ -9083,7 +8927,7 @@
 /obj/item/rogueweapon/pick,
 /obj/item/rogueweapon/pick,
 /turf/open/floor/rogue/blocks,
-/area/rogue/under/cave)
+/area/rogue/indoors/town)
 "rPu" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1
@@ -9097,20 +8941,20 @@
 	dir = 8
 	},
 /turf/open/transparent/openspace,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "rPV" = (
 /obj/effect/decal/mossy{
 	dir = 8
 	},
 /turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "rQD" = (
 /obj/structure/closet/crate/roguecloset/inn,
 /turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "rRK" = (
 /turf/closed/wall/mineral/rogue/decostone,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "rSq" = (
 /obj/structure/rack/rogue/shelf/big,
 /obj/structure/rack/rogue/shelf,
@@ -9128,21 +8972,23 @@
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "rUz" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "rUT" = (
-/obj/machinery/light/rogue/wallfire{
-	pixel_y = 32
+/obj/structure/flora/roguetree/snow{
+	icon_state = "tree3"
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/snow{
+	color = "e6f2ff"
+	},
+/area/rogue/outdoors/town)
 "rVf" = (
 /obj/machinery/light/rogue/smelter,
 /turf/open/floor/rogue/herringbone,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "rVC" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -9155,8 +9001,8 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/woods)
 "rXJ" = (
-/turf/open/floor/rogue/grasscold,
-/area/rogue)
+/turf/open/floor/rogue/dirt/ambush,
+/area/rogue/indoors/town)
 "rYb" = (
 /obj/structure/mineral_door/wood{
 	name = "house i";
@@ -9168,19 +9014,19 @@
 /obj/effect/decal/cobbleedge,
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "rYT" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "rZz" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "rZR" = (
 /obj/machinery/light/rogue/torchholder{
 	icon_state = "torchwall1";
@@ -9188,7 +9034,7 @@
 	},
 /obj/structure/fluff/alch,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "rZT" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -9197,14 +9043,14 @@
 /obj/item/kitchen/spoon,
 /obj/item/kitchen/spoon,
 /turf/open/floor/rogue/wood,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "sac" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/twig,
-/area/rogue)
+/area/rogue/outdoors/town)
 "san" = (
 /turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "sbR" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave)
@@ -9226,7 +9072,7 @@
 /turf/open/floor/rogue/snow{
 	color = "e6f2ff"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "scS" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_y = 24
@@ -9243,13 +9089,13 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "shp" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "shW" = (
 /obj/structure/fermenting_barrel/zagul,
 /obj/structure/fluff/railing/border{
@@ -9277,7 +9123,7 @@
 /obj/item/quiver/arrows,
 /obj/item/quiver/arrows,
 /turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "sij" = (
 /obj/effect/landmark/mapGenerator/rogue/cave{
 	endTurfX = 155;
@@ -9290,7 +9136,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "siD" = (
 /obj/structure/roguerock,
 /turf/open/floor/rogue/grasscold,
@@ -9301,7 +9147,7 @@
 	dir = 4
 	},
 /turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "sjv" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -9314,7 +9160,7 @@
 /obj/machinery/light/rogue/hearth,
 /obj/item/reagent_containers/glass/bucket/pot,
 /turf/open/floor/rogue/herringbone,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "skH" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/tavern)
@@ -9329,11 +9175,11 @@
 	locked = 1
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "sme" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "smK" = (
 /obj/structure/fluff/railing/fence{
 	icon_state = "fence";
@@ -9344,20 +9190,20 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "smO" = (
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/tavern)
 "snZ" = (
-/obj/structure/roguewindow/openclose{
+/obj/effect/decal/herringbone{
 	dir = 8
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/tavern)
 "soi" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "sph" = (
 /obj/machinery/light/rogue/torchholder{
 	icon_state = "torchwall1";
@@ -9378,7 +9224,7 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "sse" = (
 /obj/structure/fluff/walldeco/rpainting{
 	pixel_x = -32
@@ -9388,7 +9234,7 @@
 	dir = 5
 	},
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "ssA" = (
 /obj/structure/rack/rogue/shelf,
 /obj/item/cooking/pan{
@@ -9405,7 +9251,7 @@
 	},
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "stm" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf,
 /obj/effect/decal/cleanable/blood,
@@ -9427,7 +9273,7 @@
 /obj/item/reagent_containers/glass/mortar,
 /obj/item/mortar,
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "svu" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/herringbone,
@@ -9444,33 +9290,33 @@
 	pixel_y = -8
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "sxT" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "sBl" = (
 /obj/structure/bookcase/random,
 /obj/item/paper/scroll,
 /obj/item/natural/feather,
 /turf/open/floor/carpet/royalblack,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "sBq" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "sBP" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
 	},
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "sCB" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -9485,7 +9331,7 @@
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow,
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow,
 /turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "sDO" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -9497,15 +9343,11 @@
 	dir = 10
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "sEp" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/trufflepig,
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
-"sEN" = (
-/obj/structure/mineral_door/wood/towner/anyone,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/area/rogue/outdoors/town)
 "sGF" = (
 /obj/structure/closet/crate/chest{
 	lockid = "priest"
@@ -9554,14 +9396,14 @@
 /turf/open/floor/rogue/snow{
 	color = "e6f2ff"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "sKA" = (
 /obj/structure/stairs{
 	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "sKV" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood3"
@@ -9578,7 +9420,7 @@
 "sLt" = (
 /obj/structure/composter/halffull,
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "sML" = (
 /obj/structure/fluff/railing/fence{
 	icon_state = "fence";
@@ -9586,7 +9428,7 @@
 	},
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "sNs" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -9599,23 +9441,23 @@
 	pixel_y = 32
 	},
 /turf/open/floor/carpet/royalblack,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "sOf" = (
 /obj/structure/mineral_door/wood{
 	name = "Walters House";
 	lockid = "house2"
 	},
 /turf/open/floor/rogue/blocks,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "sON" = (
 /obj/structure/ladder{
 	pixel_y = 18
 	},
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "sPC" = (
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "sRV" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach)
@@ -9626,7 +9468,7 @@
 "sVf" = (
 /obj/structure/fluff/alch,
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "sVY" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -9636,13 +9478,11 @@
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "sWh" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/obj/effect/decal/herringbone,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/tavern)
 "sWi" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -9680,7 +9520,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "sXQ" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_y = 32
@@ -9693,15 +9533,15 @@
 "sXV" = (
 /obj/structure/closet/crate/chest/neu,
 /turf/open/floor/rogue/cobble,
-/area/rogue/under/cave)
+/area/rogue/indoors/town)
 "sYJ" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "sZF" = (
 /obj/structure/table/wood,
 /turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/under/cave)
+/area/rogue/indoors/town)
 "tbt" = (
 /obj/machinery/light/rogue/torchholder{
 	icon_state = "torchwall1";
@@ -9718,13 +9558,13 @@
 	pixel_y = 28
 	},
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "tbN" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/snow{
 	color = "e6f2ff"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "tbP" = (
 /obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -9733,7 +9573,7 @@
 /obj/structure/bed/rogue/inn,
 /obj/item/bedsheet/rogue/pelt,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "tcr" = (
 /turf/open/floor/rogue/concrete,
 /area/rogue/outdoors/beach)
@@ -9744,27 +9584,24 @@
 "tdf" = (
 /obj/structure/bookcase/random/adult,
 /turf/open/floor/carpet/red,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "tdL" = (
-/obj/machinery/light/rogue/torchholder{
-	dir = 8
+/turf/open/water/river{
+	icon_state = "rockwd";
+	dir = 4
 	},
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/outdoors/town)
 "teY" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "tfo" = (
 /obj/machinery/light/rogue/cauldron,
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "tfy" = (
 /obj/structure/fluff/railing/wood{
 	pixel_x = 1;
@@ -9789,11 +9626,11 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "tiR" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/under/cave)
+/area/rogue/indoors/town/garrison)
 "tjx" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/twig,
@@ -9811,13 +9648,13 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "tku" = (
 /obj/structure/closet/crate/chest/neu_fancy,
 /obj/item/fishingrod,
 /obj/item/rogueweapon/shovel/small,
 /turf/open/floor/rogue/wood,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "tkG" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 1;
@@ -9826,7 +9663,7 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "tlH" = (
 /obj/item/natural/rock,
 /turf/open/floor/rogue/dirt,
@@ -9861,7 +9698,7 @@
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "toL" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -9870,12 +9707,9 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach)
 "toZ" = (
-/obj/structure/fluff/railing/wood{
-	pixel_x = 1;
-	pixel_y = -8
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/obj/structure/flora/roguetree/burnt,
+/turf/open/floor/rogue/grasscold,
+/area/rogue/outdoors/town)
 "tqe" = (
 /obj/structure/far_travel,
 /turf/open/floor/rogue/dirt/road,
@@ -9889,7 +9723,7 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "ttz" = (
 /obj/structure/fluff/railing/stonehedge{
 	dir = 4
@@ -9904,10 +9738,10 @@
 /obj/structure/bed/rogue,
 /obj/item/bedsheet/rogue/wool,
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "tuX" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "tvC" = (
 /obj/item/natural/stone,
 /turf/open/floor/rogue/naturalstone,
@@ -9915,11 +9749,11 @@
 "twA" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "twC" = (
 /obj/item/paper/fluff,
 /turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/under/cave)
+/area/rogue/indoors/town)
 "twF" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/roguegrass,
@@ -9935,11 +9769,11 @@
 	pixel_y = -8
 	},
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "txx" = (
 /obj/structure/handcart,
 /turf/open/floor/rogue/herringbone,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "tAb" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -9952,11 +9786,11 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "tBy" = (
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "tCj" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors/town/tavern)
@@ -9964,11 +9798,11 @@
 /obj/structure/bed/rogue/inn/wooldouble,
 /obj/item/bedsheet/rogue/double_pelt,
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "tGN" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "tGZ" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/reagent_containers/powder/flour,
@@ -9989,7 +9823,7 @@
 	pixel_y = -8
 	},
 /turf/open/floor/rogue/wood/herringbone,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "tHk" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/dirt/road,
@@ -10001,7 +9835,7 @@
 "tID" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "tIG" = (
 /obj/structure/fluff/railing/border{
 	dir = 1;
@@ -10010,9 +9844,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/tavern)
-"tKp" = (
-/turf/open/floor/carpet/royalblack,
-/area/rogue/outdoors/rtfield)
 "tLJ" = (
 /obj/structure/flora/roguegrass/swampweed,
 /turf/open/floor/rogue/grasscold,
@@ -10047,13 +9878,13 @@
 	pixel_y = 12
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/under/cave)
+/area/rogue/indoors/town/cell)
 "tOR" = (
 /obj/structure/stairs{
 	dir = 8
 	},
 /turf/open/floor/rogue/snow,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "tOY" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -10067,7 +9898,7 @@
 	dir = 9
 	},
 /turf/open/floor/rogue/twig/platform,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "tQh" = (
 /obj/structure/flora/junglebush/b,
 /turf/open/floor/rogue/dirt/road,
@@ -10087,13 +9918,13 @@
 	pixel_y = 7
 	},
 /turf/open/floor/rogue/wood/herringbone,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "tRU" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "tSL" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -10120,7 +9951,7 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "tXZ" = (
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
@@ -10131,12 +9962,12 @@
 	},
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "uaR" = (
 /turf/open/floor/rogue/rooftop/green/corner1{
 	dir = 4
 	},
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "ubC" = (
 /turf/open/water/swamp,
 /area/rogue/outdoors/rtfield)
@@ -10150,7 +9981,7 @@
 	pixel_x = 8
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "udt" = (
 /obj/structure/closet/crate/chest/neu,
 /obj/item/reagent_containers/powder/salt,
@@ -10175,11 +10006,11 @@
 	dir = 6
 	},
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "ugF" = (
 /obj/structure/closet/crate/drawer,
 /turf/open/floor/carpet/red,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "uhu" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/roguegrass,
@@ -10190,12 +10021,12 @@
 	pixel_y = 32
 	},
 /turf/open/floor/rogue/wood/herringbone,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "ujo" = (
 /turf/open/floor/rogue/rooftop{
 	dir = 4
 	},
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "ujp" = (
 /mob/living/carbon/human/species/human/northern/bum,
 /turf/open/floor/rogue/cobblerock,
@@ -10208,7 +10039,7 @@
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "ulb" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -10229,7 +10060,7 @@
 /obj/item/reagent_containers/glass/mortar,
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "ulA" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/grasscold,
@@ -10261,13 +10092,13 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/herringbone,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "upU" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "uqb" = (
 /obj/structure/rack/rogue,
 /obj/item/rope,
@@ -10280,7 +10111,7 @@
 "uqO" = (
 /obj/structure/fluff/railing/stonehedge,
 /turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "uqV" = (
 /obj/structure/spacevine,
 /turf/open/floor/rogue/naturalstone,
@@ -10302,7 +10133,7 @@
 	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "usk" = (
 /obj/structure/table/church/m,
 /obj/item/reagent_containers/glass/cup/golden,
@@ -10316,7 +10147,7 @@
 	dir = 10
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "uty" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -10324,7 +10155,7 @@
 "utD" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/snow,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "uuE" = (
 /obj/structure/bed/rogue/inn/hay,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -10339,7 +10170,7 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/cobble,
-/area/rogue/under/cave)
+/area/rogue/indoors/town)
 "uwK" = (
 /obj/structure/flora/roguegrass/water,
 /turf/open/water/swamp,
@@ -10377,17 +10208,14 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "uEG" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/outdoors/rtfield)
+/obj/structure/roguerock,
+/turf/open/floor/rogue/snow,
+/area/rogue/outdoors/town)
 "uEJ" = (
-/obj/structure/mineral_door/wood,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/turf/closed/wall/mineral/rogue/stone/moss,
+/area/rogue/indoors/town)
 "uGz" = (
 /turf/open/water/river{
 	icon_state = "rockwd";
@@ -10396,32 +10224,32 @@
 /area/rogue/outdoors/rtfield)
 "uHt" = (
 /turf/closed/wall/mineral/rogue/wooddark,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "uHD" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /obj/effect/decal/cobbleedge{
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "uHY" = (
 /obj/item/roguebin/water,
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/under/cave)
+/area/rogue/indoors/town)
 "uId" = (
 /obj/machinery/anvil,
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "uIf" = (
 /obj/structure/roguewindow/openclose{
 	dir = 8
 	},
 /turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "uIM" = (
 /obj/structure/table/wood{
 	icon_state = "longtable_mid"
@@ -10446,34 +10274,34 @@
 	pixel_y = 24
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "uJx" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "uJQ" = (
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/wood/herringbone,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "uJZ" = (
 /obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "uMb" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+/obj/structure/flora/newtree,
+/turf/open/floor/rogue/snow{
+	color = "e6f2ff"
 	},
-/turf/open/floor/rogue/wood,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "uMK" = (
 /obj/machinery/light/rogue/torchholder{
 	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "uMX" = (
 /obj/structure/fermenting_barrel/random/water,
 /turf/open/floor/rogue/hexstone,
@@ -10485,17 +10313,15 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
 "uPQ" = (
-/obj/structure/bed/rogue/inn,
-/obj/item/bedsheet/rogue/cloth,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/hay,
+/area/rogue/indoors/town)
 "uQh" = (
 /obj/structure/stairs{
 	icon_state = "stairs";
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "uQv" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/woods)
@@ -10509,7 +10335,7 @@
 	icon_state = "vertw";
 	dir = 1
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "uSj" = (
 /turf/open/water/river{
 	icon_state = "rockwd"
@@ -10520,18 +10346,18 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "uSy" = (
 /obj/item/bedsheet/rogue/double_pelt,
 /obj/structure/bed/rogue/inn/wooldouble,
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "uSB" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "uSG" = (
 /obj/structure/flora/roguetree/normal{
 	icon_state = "free3"
@@ -10547,17 +10373,17 @@
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "uVk" = (
 /obj/structure/fluff/railing/border{
 	pixel_y = -6
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "uWv" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "uXf" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -10578,7 +10404,7 @@
 	},
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "vcT" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf,
 /turf/open/floor/rogue/snow,
@@ -10607,7 +10433,7 @@
 	pixel_x = -4
 	},
 /turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "vhT" = (
 /obj/structure/chair/bench/coucha,
 /turf/open/floor/rogue/woodturned,
@@ -10630,7 +10456,7 @@
 "vkn" = (
 /obj/structure/fermenting_barrel/water,
 /turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "vkK" = (
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/cobblerock,
@@ -10653,11 +10479,11 @@
 	},
 /obj/item/natural/feather,
 /turf/open/floor/carpet/red,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "vmW" = (
 /obj/machinery/light/rogue/forge,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "vmX" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -10672,7 +10498,7 @@
 "vpe" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/twig/platform,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "vpG" = (
 /obj/structure/table/wood{
 	icon_state = "longtable";
@@ -10680,7 +10506,7 @@
 	},
 /obj/structure/bars/shop,
 /turf/open/floor/rogue/herringbone,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "vqm" = (
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/tavern)
@@ -10691,12 +10517,12 @@
 "vqT" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "vrp" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/item/rogueweapon/hoe,
 /turf/open/floor/rogue/blocks,
-/area/rogue/under/cave)
+/area/rogue/indoors/town)
 "vrG" = (
 /obj/structure/rack/rogue/shelf/big,
 /obj/structure/rack/rogue/shelf,
@@ -10717,7 +10543,7 @@
 "vud" = (
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "vuw" = (
 /turf/open/floor/rogue/dirt/ambush,
 /area/rogue/outdoors/mountains)
@@ -10730,12 +10556,12 @@
 /area/rogue/outdoors/beach)
 "vuV" = (
 /turf/open/floor/rogue/herringbone,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "vvZ" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 4
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "vwR" = (
 /obj/machinery/light/rogue/torchholder{
 	icon_state = "torchwall1";
@@ -10749,7 +10575,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "vxC" = (
 /obj/machinery/light/rogue/smelter/great,
 /obj/machinery/light/rogue/torchholder{
@@ -10757,7 +10583,7 @@
 	dir = 8
 	},
 /turf/open/floor/rogue/herringbone,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "vxM" = (
 /obj/structure/flora/roguetree/snow{
 	icon_state = "tree4"
@@ -10777,7 +10603,7 @@
 /obj/item/rogueweapon/hammer/claw,
 /obj/item/rogueweapon/tongs,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "vBa" = (
 /obj/structure/chair/bench/coucha/r,
 /turf/open/floor/rogue/woodturned,
@@ -10787,7 +10613,7 @@
 	pixel_y = 26
 	},
 /turf/open/floor/rogue/carpet,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "vDe" = (
 /obj/structure/spacevine,
 /turf/open/floor/rogue/dirt,
@@ -10798,12 +10624,12 @@
 	pixel_y = 12
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "vDP" = (
 /obj/effect/decal/mossy,
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "vEo" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/wood,
@@ -10819,7 +10645,7 @@
 /area/rogue/indoors/town/bath)
 "vFM" = (
 /turf/open/floor/carpet/red,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "vFV" = (
 /obj/structure/flora/roguegrass/water,
 /obj/structure/spacevine,
@@ -10828,23 +10654,23 @@
 "vGx" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "vHI" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "vIa" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "vIk" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "vIK" = (
 /obj/structure/flora/roguetree/snow{
 	icon_state = "tree6"
@@ -10856,17 +10682,17 @@
 	pixel_y = 32
 	},
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "vJn" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "vJN" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "vJT" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/hoe,
@@ -10884,7 +10710,7 @@
 	pixel_y = -1
 	},
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "vKq" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -10893,7 +10719,7 @@
 /obj/item/paper,
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "vKF" = (
 /obj/structure/closet/dirthole/grave,
 /turf/open/floor/rogue/dirt/road,
@@ -10907,14 +10733,14 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/snow,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "vNx" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/cooking/pan{
 	pixel_y = 28
 	},
 /turf/open/floor/rogue/blocks,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "vOy" = (
 /obj/structure/flora/bush,
 /turf/open/floor/rogue/grasscold,
@@ -10927,31 +10753,11 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "vPI" = (
 /mob/living/carbon/human/species/goblin/npc/cave,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
-"vQj" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/rack/rogue/shelf,
-/obj/item/reagent_containers/glass/bottle/rogue/beer/gronnmead{
-	pixel_y = 45;
-	pixel_x = -5
-	},
-/obj/item/reagent_containers/glass/bottle/rogue/beer/zagul{
-	pixel_y = 45
-	},
-/obj/item/reagent_containers/glass/bottle/rogue/wine{
-	pixel_y = 45;
-	pixel_x = 10
-	},
-/obj/item/reagent_containers/glass/bottle/rogue/wine{
-	pixel_y = 45;
-	pixel_x = 5
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
 "vQB" = (
 /obj/structure/flora/roguetree/normal{
 	icon_state = "free5"
@@ -10959,13 +10765,11 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/woods)
 "vSd" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
+/obj/structure/fluff/railing/wood{
+	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/wood,
+/area/rogue/outdoors/town)
 "vTa" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -10975,7 +10779,7 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "vTH" = (
 /turf/closed/mineral/random/rogue/high,
 /area/rogue/outdoors/rtfield)
@@ -10984,21 +10788,16 @@
 	dir = 4
 	},
 /turf/closed,
-/area/rogue/indoors)
-"vUb" = (
-/obj/machinery/light/rogue/hearth,
-/obj/item/reagent_containers/glass/bucket/pot/stone,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "vUw" = (
 /obj/structure/mineral_door/wood/violet{
 	keylock = 0
 	},
 /turf/open/floor/rogue/greenstone,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "vUL" = (
-/turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/turf/closed/wall/mineral/rogue/stone,
+/area/rogue/outdoors/town)
 "vVR" = (
 /obj/structure/fluff/walldeco/maidensigil,
 /turf/open/floor/rogue/tile/bath,
@@ -11014,19 +10813,19 @@
 /turf/open/floor/rogue/snow{
 	color = "e6f2ff"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "vXU" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 1
 	},
 /turf/open/floor/rogue/twig/platform,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "vYw" = (
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town/garrison)
 "vYN" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/saiga/saigabuck,
 /turf/open/floor/rogue/snow{
@@ -11050,22 +10849,21 @@
 "vZE" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/under/cave)
+/area/rogue/indoors/town)
 "vZZ" = (
-/obj/structure/fermenting_barrel/water,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/town)
 "waG" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
 	dir = 9
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "waL" = (
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/under/cave)
+/area/rogue/indoors/town/cell)
 "waT" = (
 /obj/structure/flora/roguetree/normal{
 	icon_state = "free2"
@@ -11088,7 +10886,7 @@
 	dir = 10
 	},
 /turf/open/floor/rogue/grasscold,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "wcg" = (
 /obj/structure/roguerock,
 /turf/open/floor/rogue/grasscold,
@@ -11103,14 +10901,14 @@
 	},
 /obj/item/rogueweapon/huntingknife/chefknife,
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "wgk" = (
 /turf/closed/mineral/random/rogue/med,
 /area/rogue/outdoors/woods)
 "wgQ" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town)
 "wgT" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -11118,7 +10916,7 @@
 /obj/item/book/rogue/robber,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "whv" = (
 /obj/structure/closet/crate/chest/wicker,
 /obj/machinery/light/rogue/torchholder{
@@ -11135,7 +10933,7 @@
 	amount = 10
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "wih" = (
 /obj/structure/table/church,
 /obj/item/candle/yellow,
@@ -11144,13 +10942,13 @@
 "wio" = (
 /obj/structure/mineral_door/wood/towner/anyone,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "wiu" = (
 /obj/machinery/light/rogue/lanternpost{
 	dir = 1
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "wiv" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -11165,11 +10963,11 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "wjg" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "wkg" = (
 /obj/effect/decal/cleanable/blood,
 /turf/closed/mineral/random/rogue/high,
@@ -11177,7 +10975,7 @@
 "wku" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/snow,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "wkC" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -11186,7 +10984,7 @@
 	},
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "wkG" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/beach)
@@ -11199,7 +10997,7 @@
 	pixel_y = 26
 	},
 /turf/open/floor/rogue/blocks/platform,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "wlP" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood3"
@@ -11213,7 +11011,7 @@
 	pixel_x = 2
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "wmH" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -11228,14 +11026,14 @@
 /turf/open/floor/rogue/snow{
 	color = "e6f2ff"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "wni" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/outdoors/mountains)
 "wnE" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "wnS" = (
 /obj/structure/fluff/walldeco/painting{
 	pixel_x = 30
@@ -11254,7 +11052,7 @@
 	pixel_x = -5
 	},
 /turf/open/floor/carpet/red,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "woj" = (
 /obj/structure/table/wood{
 	icon_state = "longtable";
@@ -11279,7 +11077,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "wqE" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -11304,14 +11102,11 @@
 "wra" = (
 /obj/structure/chair/bench/coucha,
 /turf/open/floor/rogue/wood/herringbone,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "wrd" = (
-/obj/structure/stairs{
-	icon_state = "stairs";
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grasscold,
+/area/rogue/outdoors/town)
 "wtK" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -11319,7 +11114,7 @@
 	pixel_x = -6
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "wtR" = (
 /obj/vehicle/ridden/lavaboat{
 	dir = 4;
@@ -11337,7 +11132,7 @@
 	},
 /obj/structure/closet/crate/chest/crate,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "wvf" = (
 /obj/structure/handcart{
 	icon_state = "cart-empty";
@@ -11356,22 +11151,23 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "wxW" = (
-/obj/structure/bed/rogue/inn/double,
-/obj/item/bedsheet/rogue/double_pelt,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/obj/structure/flora/roguetree/burnt,
+/turf/open/floor/rogue/snow{
+	color = "e6f2ff"
+	},
+/area/rogue/outdoors/town)
 "wza" = (
 /obj/structure/roguemachine/mail,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "wzC" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
 	},
 /turf/open/floor/rogue/hay,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "wAc" = (
 /obj/structure/fluff/traveltile{
 	aportalid = "forestout_cave";
@@ -11391,25 +11187,25 @@
 /turf/open/floor/rogue/rooftop{
 	icon_state = "roofg"
 	},
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "wBu" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/item/paper/fluff,
 /turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/under/cave)
+/area/rogue/indoors/town)
 "wDm" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "wDU" = (
 /obj/structure/roguewindow/openclose{
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "wED" = (
 /turf/open/floor/rogue/grasscold,
 /area/rogue/under/cave)
@@ -11420,10 +11216,10 @@
 "wFo" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/grassred,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "wFu" = (
-/turf/closed/wall/mineral/rogue/wooddark/horizontal,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/cell)
 "wFC" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -11436,7 +11232,7 @@
 	},
 /obj/structure/table/wood,
 /turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "wGn" = (
 /turf/closed/wall/mineral/rogue/tent,
 /area/rogue/outdoors/woods)
@@ -11446,7 +11242,7 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/under/cave)
+/area/rogue/indoors/town/garrison)
 "wGY" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -11462,21 +11258,21 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "wJf" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
 	},
 /obj/item/rogueweapon/hammer,
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "wJw" = (
 /obj/machinery/light/rogue/torchholder{
 	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/carpet,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "wKz" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/reagent_containers/glass/bucket/pot/stone,
@@ -11491,12 +11287,14 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
 "wNi" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/obj/effect/spawner/roguemap/stump,
+/turf/open/floor/rogue/snow{
+	color = "e6f2ff"
+	},
+/area/rogue/outdoors/town)
 "wNB" = (
 /turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "wNI" = (
 /obj/machinery/light/rogue/torchholder{
 	icon_state = "torchwall1";
@@ -11518,7 +11316,7 @@
 "wOE" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "wPI" = (
 /obj/machinery/light/rogue/torchholder{
 	icon_state = "torchwall1";
@@ -11529,7 +11327,7 @@
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "wQq" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/indoors/town/tavern)
@@ -11539,7 +11337,7 @@
 	dir = 8
 	},
 /turf/open/floor/rogue/carpet,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "wQM" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/rogue/dirt/road,
@@ -11562,13 +11360,13 @@
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "wSX" = (
 /obj/structure/fluff/railing/stonehedge{
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "wTK" = (
 /obj/machinery/light/rogue/torchholder{
 	icon_state = "torchwall1";
@@ -11585,7 +11383,7 @@
 	lockid = "flints"
 	},
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/under/cave)
+/area/rogue/indoors/town)
 "wVQ" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/naturalstone,
@@ -11621,7 +11419,7 @@
 "wZe" = (
 /obj/effect/landmark/start/veteran,
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "xbg" = (
 /obj/structure/closet/crate/roguecloset/inn,
 /turf/open/floor/rogue/churchrough,
@@ -11646,7 +11444,7 @@
 "xbr" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "xcO" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -11661,11 +11459,11 @@
 "xeq" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/snow,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "xeW" = (
 /obj/structure/mineral_door/wood/towner/blacksmith,
 /turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "xeY" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/dirt/road,
@@ -11684,21 +11482,21 @@
 "xgy" = (
 /obj/structure/fluff/dryingrack,
 /turf/open/floor/rogue/blocks,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "xgC" = (
 /obj/structure/fermenting_barrel/water{
 	pixel_x = 7;
 	pixel_y = 14
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "xgG" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
 	},
 /obj/structure/rack/rogue/shelf/big,
 /turf/open/floor/rogue/wood/herringbone,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "xgU" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/reagent_containers/glass/cup/wooden,
@@ -11716,22 +11514,22 @@
 "xhS" = (
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "xin" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "xiF" = (
 /obj/structure/flora/roguegrass/bush,
 /obj/structure/fluff/railing/wood{
 	dir = 1
 	},
 /turf/open/floor/rogue/grasscold,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "xiN" = (
 /obj/structure/bars/steel,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/under/cave)
+/area/rogue/indoors/town/cell)
 "xki" = (
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/wood,
@@ -11741,7 +11539,7 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "xlq" = (
 /obj/item/natural/rock,
 /turf/open/floor/rogue/dirt/road,
@@ -11751,7 +11549,7 @@
 	lockid = "house6"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "xmL" = (
 /obj/structure/fluff/traveltile/vampire{
 	aportalid = "vampexit";
@@ -11769,7 +11567,7 @@
 "xnl" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "xnx" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/effect/decal/cleanable/blood/gibs/limb,
@@ -11780,7 +11578,7 @@
 	name = "hotspring";
 	desc = "Still and idyllic hot water that flows through meadows."
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "xrQ" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -11812,20 +11610,20 @@
 "xwA" = (
 /obj/structure/well,
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "xxv" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/fish/koi,
 /turf/open/water/pond{
 	name = "hotspring";
 	desc = "Still and idyllic hot water that flows through meadows."
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "xyp" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "xzw" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -11833,7 +11631,7 @@
 	},
 /obj/item/rogueweapon/huntingknife/chefknife,
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "xzz" = (
 /obj/structure/fluff/railing/fence{
 	icon_state = "fence";
@@ -11844,7 +11642,7 @@
 	dir = 8
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "xzP" = (
 /obj/structure/fluff/railing/wood,
 /obj/structure/fluff/railing/wood{
@@ -11853,7 +11651,7 @@
 	pixel_x = 8
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "xAZ" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/tavern)
@@ -11871,11 +11669,11 @@
 /obj/item/reagent_containers/glass/bottle/waterskin,
 /obj/item/flashlight/flare/torch/lantern,
 /turf/open/floor/rogue/cobble,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "xCL" = (
 /obj/structure/mineral_door/swing_door,
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "xCM" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -11891,8 +11689,8 @@
 	},
 /area/rogue/outdoors/woods)
 "xDp" = (
-/turf/closed/wall/mineral/rogue/stonebrick,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/snow,
+/area/rogue/outdoors/town)
 "xEl" = (
 /obj/structure/closet/dirthole/closed/loot,
 /turf/open/floor/rogue/grasscold,
@@ -11910,14 +11708,14 @@
 	dir = 10
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "xIP" = (
 /turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/outdoors/mountains)
+/area/rogue/outdoors/town)
 "xIT" = (
 /obj/machinery/light/rogue/oven/west,
 /turf/open/floor/rogue/herringbone,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "xLg" = (
 /obj/structure/flora/roguegrass/water,
 /turf/open/water/swamp/deep,
@@ -11928,7 +11726,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/under/cave)
+/area/rogue/indoors/town)
 "xOi" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -11936,7 +11734,7 @@
 	},
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "xOt" = (
 /obj/machinery/light/rogue/torchholder{
 	icon_state = "torchwall1";
@@ -11944,7 +11742,7 @@
 	},
 /obj/structure/rack/rogue/shelf/biggest,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "xOy" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -11959,7 +11757,7 @@
 /obj/structure/table/vtable,
 /obj/item/storage/box/matches,
 /turf/open/floor/rogue/wood/herringbone,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "xQA" = (
 /obj/structure/bed/rogue/inn,
 /obj/item/bedsheet/rogue/wool,
@@ -11970,11 +11768,11 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/woodturned/nosmooth,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "xRc" = (
 /obj/structure/closet/crate/chest/crate,
 /turf/open/floor/rogue/carpet,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "xRe" = (
 /obj/structure/spacevine,
 /obj/structure/spacevine,
@@ -11988,14 +11786,14 @@
 	dir = 8
 	},
 /turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "xSf" = (
 /obj/structure/fluff/railing/wood{
 	icon_state = "woodrailing";
 	dir = 4
 	},
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "xWm" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/cooking/pan,
@@ -12016,7 +11814,7 @@
 "xXs" = (
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/grasscold,
-/area/rogue/outdoors/rtfield)
+/area/rogue/outdoors/town)
 "xXw" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -12028,7 +11826,7 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "xXW" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave)
@@ -12041,23 +11839,23 @@
 	pixel_y = 32
 	},
 /turf/open/floor/carpet/red,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "yaE" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
-/area/rogue/under/cave)
+/area/rogue/indoors/town)
 "ydd" = (
 /obj/structure/mineral_door/wood/towner/anyone,
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "ydI" = (
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "ydT" = (
 /obj/structure/closet/crate/chest/old_crate,
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "yfy" = (
 /obj/item/rogue/instrument/flute,
 /obj/structure/flora/roguetree/stump,
@@ -12079,7 +11877,7 @@
 	pixel_x = -10
 	},
 /turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 "ygP" = (
 /obj/structure/spacevine,
 /turf/open/floor/rogue/naturalstone,
@@ -12111,7 +11909,7 @@
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/town/garrison)
 "ymg" = (
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/rtfield)
@@ -12120,7 +11918,7 @@
 	lockid = "houseshop"
 	},
 /turf/open/floor/rogue/twig,
-/area/rogue/indoors)
+/area/rogue/indoors/town)
 
 (1,1,1) = {"
 pNQ
@@ -20183,11 +19981,11 @@ hWI
 hWI
 uBR
 uBR
-bxn
-bxn
-bxn
-bxn
-bxn
+lRw
+lRw
+lRw
+lRw
+lRw
 etD
 etD
 etD
@@ -20338,13 +20136,13 @@ xXW
 hWI
 hWI
 uBR
-bxn
-bxn
-bxn
+lRw
+lRw
+lRw
 rQD
 kUZ
 kUZ
-bxn
+lRw
 etD
 etD
 etD
@@ -20495,13 +20293,13 @@ kfB
 hWI
 hWI
 uBR
-bxn
+lRw
 aGa
 kUZ
 kUZ
 kUZ
 bvp
-bxn
+lRw
 etD
 etD
 etD
@@ -20652,13 +20450,13 @@ vDe
 hWI
 hWI
 uBR
-bxn
-bxn
-bxn
+lRw
+lRw
+lRw
 cSr
 kUZ
 kUZ
-bxn
+lRw
 etD
 etD
 etD
@@ -20811,11 +20609,11 @@ hWI
 hWI
 uBR
 uBR
-bxn
-bxn
-bxn
-bxn
-bxn
+lRw
+lRw
+lRw
+lRw
+lRw
 etD
 etD
 etD
@@ -21970,9 +21768,9 @@ etD
 etD
 yaE
 uvE
-qhe
-qhe
-qhe
+sPC
+sPC
+sPC
 fTZ
 yaE
 etD
@@ -22127,9 +21925,9 @@ etD
 etD
 yaE
 nqR
-qhe
-qhe
-qhe
+sPC
+sPC
+sPC
 sXV
 yaE
 etD
@@ -22285,8 +22083,8 @@ etD
 yaE
 yaE
 xLL
-qhe
-qhe
+sPC
+sPC
 sXV
 yaE
 etD
@@ -22441,9 +22239,9 @@ etD
 etD
 yaE
 nqR
-qhe
-qhe
-qhe
+sPC
+sPC
+sPC
 sXV
 yaE
 etD
@@ -22598,9 +22396,9 @@ etD
 etD
 yaE
 eIo
-qhe
-qhe
-qhe
+sPC
+sPC
+sPC
 ekW
 yaE
 etD
@@ -23493,12 +23291,12 @@ sbR
 sbR
 hWI
 hWI
-abV
-abV
-abV
-abV
-abV
-abV
+yaE
+yaE
+yaE
+yaE
+yaE
+yaE
 xXW
 xXW
 sbR
@@ -23650,12 +23448,12 @@ fvg
 hWI
 hWI
 hWI
-abV
+yaE
 vuV
 vuV
 vuV
 vuV
-abV
+yaE
 hWI
 xXW
 oUl
@@ -23807,12 +23605,12 @@ hWI
 hWI
 uBR
 uBR
-abV
+yaE
 uop
 vuV
 vuV
 vuV
-abV
+yaE
 hWI
 hWI
 xXW
@@ -23964,12 +23762,12 @@ hWI
 uBR
 uBR
 uBR
-abV
-abV
+yaE
+yaE
 iTH
 vuV
 fkl
-abV
+yaE
 hWI
 hWI
 hWI
@@ -23994,14 +23792,14 @@ hWI
 hWI
 hWI
 hWI
-rDj
-rDj
-rDj
-rDj
-rDj
-rDj
-rDj
-rDj
+fJU
+fJU
+fJU
+fJU
+fJU
+fJU
+fJU
+fJU
 hWI
 vDe
 xXW
@@ -24121,12 +23919,12 @@ uBR
 uBR
 uBR
 uBR
-abV
+yaE
 vuV
 vuV
 vuV
 vuV
-abV
+yaE
 hWI
 hWI
 hWI
@@ -24151,14 +23949,14 @@ hWI
 hWI
 uBR
 uBR
-rDj
+fJU
 tON
-dFC
-dFC
+wFu
+wFu
 waL
 xiN
 dFC
-rDj
+fJU
 hWI
 vDe
 vDe
@@ -24278,12 +24076,12 @@ uBR
 uBR
 uBR
 gzl
-abV
+yaE
 vuV
 vuV
 vuV
 mUd
-abV
+yaE
 uBR
 hWI
 hWI
@@ -24308,14 +24106,14 @@ uBR
 uBR
 uBR
 uBR
-rDj
-dFC
+fJU
+wFu
 rGw
-dFC
-dFC
+wFu
+wFu
 xiN
 dFC
-rDj
+fJU
 hWI
 hWI
 vDe
@@ -24440,7 +24238,7 @@ vuV
 vuV
 vuV
 mUd
-abV
+yaE
 uBR
 uBR
 hWI
@@ -24465,14 +24263,14 @@ uBR
 uBR
 uBR
 uBR
-rDj
-dFC
-dFC
-dFC
+fJU
+wFu
+wFu
+wFu
 qAs
 xiN
 dFC
-rDj
+fJU
 hWI
 hWI
 vDe
@@ -24592,12 +24390,12 @@ etD
 etD
 uBR
 dSI
-abV
+yaE
 vuV
 vuV
 mUd
 mUd
-abV
+yaE
 uBR
 uBR
 hWI
@@ -24622,14 +24420,14 @@ etD
 etD
 uBR
 uBR
-rDj
+fJU
 xiN
 xiN
 cXW
 xiN
 xiN
 dFC
-rDj
+fJU
 uBR
 hWI
 hWI
@@ -24749,12 +24547,12 @@ etD
 etD
 etD
 etD
-abV
+yaE
 iTH
 vuV
 mUd
 rCA
-abV
+yaE
 uBR
 uBR
 hWI
@@ -24779,14 +24577,14 @@ etD
 etD
 etD
 etD
-rDj
+fJU
 dFC
 dFC
 dFC
 dFC
 dFC
 dFC
-rDj
+fJU
 uBR
 uBR
 hWI
@@ -24906,12 +24704,12 @@ etD
 etD
 etD
 uBR
-abV
+yaE
 vuV
 vuV
 vuV
 vuV
-abV
+yaE
 uBR
 uBR
 hWI
@@ -24936,14 +24734,14 @@ etD
 etD
 etD
 etD
-rDj
+fJU
 dFC
 dFC
 dFC
 dFC
 tiR
 wGr
-rDj
+fJU
 uBR
 uBR
 hWI
@@ -25063,12 +24861,12 @@ etD
 etD
 etD
 uBR
-abV
+yaE
 txx
 txx
 txx
 txx
-abV
+yaE
 uBR
 hWI
 hWI
@@ -25093,14 +24891,14 @@ etD
 etD
 etD
 etD
-rDj
+fJU
 pZF
 qYO
 dFC
 dFC
 dFC
 dsB
-rDj
+fJU
 etD
 uBR
 uBR
@@ -25220,12 +25018,12 @@ etD
 etD
 etD
 uBR
-abV
-abV
-abV
-abV
-abV
-abV
+yaE
+yaE
+yaE
+yaE
+yaE
+yaE
 uBR
 hWI
 hWI
@@ -25250,14 +25048,14 @@ etD
 etD
 etD
 etD
-rDj
+fJU
 dFC
 cTU
 dFC
 dFC
 dFC
 dFC
-rDj
+fJU
 etD
 etD
 uBR
@@ -25407,14 +25205,14 @@ etD
 etD
 etD
 etD
-rDj
-rDj
-rDj
-rDj
-rDj
-rDj
-rDj
-rDj
+fJU
+fJU
+fJU
+fJU
+fJU
+fJU
+fJU
+fJU
 etD
 etD
 etD
@@ -26195,17 +25993,17 @@ aCh
 aCh
 rDj
 lfj
-cQd
-cQd
-cQd
-cQd
-cQd
-cQd
-cQd
-cQd
-cQd
-cQd
-cQd
+ccX
+ccX
+ccX
+ccX
+ccX
+ccX
+ccX
+ccX
+ccX
+ccX
+ccX
 uBR
 hWI
 hWI
@@ -26352,17 +26150,17 @@ eZs
 aCh
 rDj
 cZT
-cQd
+ccX
 sNu
-tKp
-tKp
+kzw
+kzw
 sBl
-cQd
+ccX
 rZR
-rej
-rej
+acN
+acN
 glT
-cQd
+ccX
 uBR
 uBR
 hWI
@@ -26509,17 +26307,17 @@ sbR
 xXW
 rDj
 hnT
-cQd
-tKp
-tKp
-tKp
+ccX
+kzw
+kzw
+kzw
 eJJ
-cQd
+ccX
 hkz
-rej
-rej
+acN
+acN
 mdd
-cQd
+ccX
 uBR
 uBR
 hWI
@@ -26666,17 +26464,17 @@ rDj
 sbR
 sbR
 xXW
-cQd
+ccX
 dll
-tKp
-tKp
+kzw
+kzw
 qVA
-cQd
+ccX
 oHP
-rej
-rej
+acN
+acN
 gOm
-cQd
+ccX
 uBR
 uBR
 uBR
@@ -26823,17 +26621,17 @@ hWI
 hWI
 xXW
 sbR
-cQd
-cQd
-cQd
-cZg
-cQd
-cQd
-cQd
-rej
-rej
-cQd
-cQd
+ccX
+ccX
+ccX
+ooG
+ccX
+ccX
+ccX
+acN
+acN
+ccX
+ccX
 uBR
 uBR
 uBR
@@ -26980,24 +26778,24 @@ hWI
 rDj
 sbR
 rDj
-cQd
-cQd
-rej
-rej
-rej
-cZg
+ccX
+ccX
+acN
+acN
+acN
+ooG
 jwP
-rej
-rej
+acN
+acN
 qij
-cQd
+ccX
 hWI
-rDj
-rDj
-rDj
-rDj
-rDj
-rDj
+ejK
+ejK
+ejK
+ejK
+ejK
+ejK
 vDe
 sbR
 sbR
@@ -27137,24 +26935,24 @@ tAb
 lWi
 sbR
 etD
-cQd
+ccX
 kWQ
-rej
-rej
-rej
-cQd
-fcm
+acN
+acN
+acN
+ccX
+rCp
 qFI
-rej
+acN
 qij
-cQd
+ccX
 hWI
-rDj
-xXW
-xXW
-xXW
+ejK
+aaO
+aaO
+aaO
 fna
-rDj
+ejK
 pNQ
 sbR
 sbR
@@ -27294,25 +27092,25 @@ eZs
 hVe
 hVe
 hVe
-cQd
-rej
-rej
-rej
-rej
-cQd
-fcm
+ccX
+acN
+acN
+acN
+acN
+ccX
+rCp
 qFI
-rej
+acN
 qij
-cQd
+ccX
 hWI
-rDj
-sbR
-sbR
-xXW
-xXW
-rDj
-rDj
+ejK
+vZZ
+vZZ
+aaO
+aaO
+ejK
+ejK
 pNQ
 sbR
 sbR
@@ -27451,25 +27249,25 @@ xXW
 hVe
 qZE
 lWH
-cQd
-rUT
-rej
-rej
-rej
-cQd
-fcm
+ccX
+gog
+acN
+acN
+acN
+ccX
+rCp
 qFI
-rej
+acN
 qij
-cQd
+ccX
 hWI
-rDj
-sbR
-sbR
-sbR
-xXW
+ejK
+vZZ
+vZZ
+vZZ
+aaO
 prk
-rDj
+ejK
 pNQ
 pNQ
 sbR
@@ -27608,25 +27406,25 @@ qJc
 hVe
 iMF
 lWH
-cQd
-sWh
-sWh
-sWh
-sWh
-cQd
+ccX
+qGr
+qGr
+qGr
+qGr
+ccX
 wuT
 qFI
-rej
+acN
 jdd
-cQd
+ccX
 hWI
-rDj
-xXW
-sbR
-xXW
-xXW
-rDj
-rDj
+ejK
+aaO
+vZZ
+aaO
+aaO
+ejK
+ejK
 pNQ
 pNQ
 sbR
@@ -27765,24 +27563,24 @@ lWH
 hWI
 kFR
 gSx
-cQd
-cQd
-cQd
-cQd
-cQd
-cQd
-cQd
-cQd
-cQd
-cQd
-cQd
+ccX
+ccX
+ccX
+ccX
+ccX
+ccX
+ccX
+ccX
+ccX
+ccX
+ccX
 hWI
-rDj
-sbR
-xXW
-xXW
-xXW
-rDj
+ejK
+vZZ
+aaO
+aaO
+aaO
+ejK
 pNQ
 pNQ
 lfj
@@ -27934,12 +27732,12 @@ hVe
 hWI
 hWI
 hWI
-rDj
-rDj
-rDj
-rDj
-rDj
-rDj
+ejK
+ejK
+ejK
+ejK
+ejK
+ejK
 pNQ
 pNQ
 xXW
@@ -29645,9 +29443,9 @@ etD
 etD
 uBR
 uBR
-rDj
-rDj
-rDj
+lRw
+lRw
+lRw
 uBR
 uBR
 uBR
@@ -29802,9 +29600,9 @@ etD
 etD
 uBR
 uBR
-rDj
+lRw
 mVu
-rDj
+lRw
 uBR
 uBR
 uBR
@@ -29959,9 +29757,9 @@ etD
 etD
 uBR
 uBR
-hnT
-hVe
-hVe
+iNO
+kUZ
+kUZ
 hXU
 acH
 pNQ
@@ -30115,12 +29913,12 @@ etD
 etD
 uBR
 uBR
-dKO
-sbR
-sbR
-dKO
-sbR
-dKO
+rXJ
+qyk
+qyk
+rXJ
+qyk
+rXJ
 pNQ
 pNQ
 pNQ
@@ -30273,11 +30071,11 @@ etD
 uBR
 uBR
 rPr
-sbR
-izJ
-gdc
-dKO
-sbR
+qyk
+maz
+icA
+rXJ
+qyk
 pNQ
 pNQ
 pNQ
@@ -30430,11 +30228,11 @@ etD
 uBR
 uBR
 rPr
-dKO
-sbR
-dKO
-dKO
-dKO
+rXJ
+qyk
+rXJ
+rXJ
+rXJ
 uBR
 uBR
 uBR
@@ -30587,8 +30385,8 @@ etD
 etD
 uBR
 uBR
-dKO
-dKO
+rXJ
+rXJ
 vrp
 rPr
 uBR
@@ -40060,10 +39858,10 @@ jMT
 jMT
 cij
 iUV
-rej
+acN
 cij
-kvF
-fyG
+lBl
+cyW
 poC
 cij
 eUz
@@ -40207,21 +40005,21 @@ hWI
 dSI
 dSI
 hWI
-mPR
-mPR
-mPR
-mPR
-mPR
-mPR
+oLW
+oLW
+oLW
+oLW
+oLW
+oLW
 cij
 cij
 cij
-rej
-rej
+acN
+acN
 cij
-tKp
-tKp
-uEG
+kzw
+kzw
+opX
 cij
 eUz
 eUz
@@ -40364,21 +40162,21 @@ dSI
 dSI
 dSI
 dPz
-mPR
-kSI
-vZZ
-mPR
+oLW
+dGF
+vkn
+oLW
 fOB
-bSo
-vYw
-sWh
+dzE
+jaR
+qGr
 cij
-rej
-rej
+acN
+acN
 xlX
-rej
-rej
-rej
+acN
+acN
+acN
 cij
 eUz
 eUz
@@ -40521,21 +40319,21 @@ dSI
 umP
 dSI
 dPz
-mPR
-vQj
-vDq
-mPR
+oLW
+iFY
+fZj
+oLW
 iVJ
-age
-rej
-cOy
+fdv
+acN
+dlX
 lwR
-rej
-rej
+acN
+acN
 cij
-rej
-iwe
-dxc
+acN
+qMW
+lkN
 cij
 eUz
 eUz
@@ -40643,16 +40441,16 @@ dPV
 mVe
 fsP
 fsP
-uGz
-uGz
-uGz
-uGz
-uGz
-ymg
-ymg
-ymg
-ymg
-ymg
+age
+age
+age
+age
+age
+kqj
+kqj
+kqj
+kqj
+kqj
 uSj
 uSj
 uSj
@@ -40678,21 +40476,21 @@ xXW
 dSI
 dPz
 dPz
-mPR
-iSL
-iSL
+oLW
+sPC
+sPC
 mtb
-iSL
-jGz
-rej
+sPC
+fzT
+acN
 ydI
 cij
-rej
-rej
+acN
+acN
 cij
 cij
 cij
-snZ
+wDU
 cij
 eUz
 eUz
@@ -40798,26 +40596,26 @@ uGz
 uGz
 uGz
 uGz
-uJx
+vSd
 dJz
-uGz
-uGz
-uGz
-fsP
-dPV
-dPV
-fRr
-fRr
-dPV
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-sLi
+age
+age
+age
+puh
+ada
+ada
+pOn
+pOn
+ada
+kqj
+kqj
+kqj
+kqj
+kqj
+kqj
+kqj
+kqj
+tdL
 sLi
 ymg
 fsP
@@ -40829,27 +40627,27 @@ fsP
 dPz
 eUz
 eUz
-jfy
+quo
 xXW
 xXW
 xXW
 dPz
 dPz
-mPR
+oLW
 whv
-ejK
+cBU
 cij
 nka
-olP
-rej
-rej
+pAw
+acN
+acN
 cij
-rej
-rej
-rej
-rej
-rej
-rej
+acN
+acN
+acN
+acN
+acN
+acN
 cij
 eUz
 eUz
@@ -40907,17 +40705,17 @@ fRr
 fRr
 fRr
 fRr
-fRr
-fRr
-spZ
-fRr
-tLJ
-fRr
-fRr
-fRr
-dPV
-lnn
-dPV
+pOn
+pOn
+bJz
+pOn
+cOy
+pOn
+pOn
+pOn
+ada
+xDp
+ada
 dPV
 dPV
 dPV
@@ -40955,26 +40753,26 @@ uGz
 uGz
 uGz
 uGz
-uJx
+vSd
 dJz
-uGz
-fsP
-fsP
-fsP
-fRr
-dPV
-fRr
-fRr
-fRr
-dPV
-dPV
-dPV
-dPV
-dPV
-loN
-dPV
-ymg
-sLi
+age
+puh
+puh
+puh
+pOn
+ada
+pOn
+pOn
+pOn
+ada
+ada
+ada
+ada
+ada
+rvZ
+ada
+kqj
+tdL
 sLi
 ymg
 fsP
@@ -40986,14 +40784,14 @@ fsP
 dPz
 dPz
 eUz
-jfy
+quo
 xXW
 sbR
 xXW
 dPz
 dPz
-mPR
-mPR
+oLW
+oLW
 cij
 cij
 cij
@@ -41002,11 +40800,11 @@ qKM
 cij
 cij
 iUV
-rej
-rej
-rej
-rej
-kAA
+acN
+acN
+acN
+acN
+lHP
 cij
 eUz
 eUz
@@ -41055,16 +40853,16 @@ fRr
 qwj
 lnn
 lnn
-lnn
-lnn
+xDp
+xDp
+pOn
+pOn
+pOn
+pOn
+pOn
 fRr
 fRr
-fRr
-fRr
-fRr
-fRr
-fRr
-fRr
+pOn
 bLq
 bLq
 bLq
@@ -41074,7 +40872,7 @@ bLq
 bLq
 bLq
 bLq
-abb
+iXK
 dPV
 dPV
 dPV
@@ -41110,28 +40908,28 @@ uGz
 uGz
 uGz
 uGz
-ymg
-ymg
-fsP
-fsP
-fsP
-fsP
-fsP
-fsP
-fsP
-fRr
-fRr
-fwr
-fwr
+kqj
+kqj
+puh
+puh
+puh
+puh
+puh
+puh
+puh
+pOn
+pOn
+lAV
+lAV
 koU
-dPV
-abb
-dPV
-dPV
-dPV
-dPV
-ymg
-uSj
+ada
+iXK
+ada
+ada
+ada
+ada
+kqj
+kSI
 sLi
 ymg
 fsP
@@ -41155,15 +40953,15 @@ cij
 atP
 gsc
 fzp
-rej
-rej
+acN
+acN
 cij
-rej
-rej
-rej
-rej
-rej
-rej
+acN
+acN
+acN
+acN
+acN
+acN
 cij
 eUz
 eUz
@@ -41211,27 +41009,27 @@ lnn
 dPV
 lnn
 lnn
-lnn
-lnn
-lnn
-lnn
-fRr
-fRr
-spZ
-fRr
-fRr
-lnn
-mVe
+xDp
+xDp
+xDp
+xDp
+pOn
+pOn
+bJz
+pOn
+pOn
+xDp
+hbl
 bLq
-fsP
-fsP
-fsP
-fsP
-fsP
-fsP
-fsP
+puh
+puh
+puh
+puh
+puh
+puh
+puh
 bLq
-dPV
+ada
 dPV
 dPV
 dPV
@@ -41265,31 +41063,31 @@ sLi
 sLi
 uGz
 uGz
-ymg
-ymg
-ymg
-fRr
-fRr
-fRr
-fRr
-fRr
-fRr
+kqj
+kqj
+kqj
+pOn
+pOn
+pOn
+pOn
+pOn
+pOn
 rNp
-dPV
-fsP
-fRr
+ada
+puh
+pOn
 kEG
-fRr
-fRr
-lnn
-lnn
-lnn
-lnn
-lnn
-dPV
-ymg
-uSj
-sLi
+pOn
+pOn
+xDp
+xDp
+xDp
+xDp
+xDp
+ada
+kqj
+kSI
+tdL
 ymg
 fRr
 fsP
@@ -41301,8 +41099,8 @@ vOy
 fRr
 fRr
 fRr
-fsP
-ylN
+puh
+rej
 dPz
 dPz
 dPz
@@ -41312,15 +41110,15 @@ rli
 fzp
 fzp
 fzp
-rej
-rej
+acN
+acN
 qKM
-rej
-rej
-rej
-rej
-rej
-rej
+acN
+acN
+acN
+acN
+acN
+acN
 cij
 eUz
 eUz
@@ -41347,48 +41145,48 @@ dPz
 dPz
 dPz
 dPz
-dPV
-dPV
-dPV
-dPV
-dPV
+ada
+ada
+ada
+ada
+ada
 hDp
 hDp
-fsP
+puh
 joV
-fsP
-dPV
-dPV
-abb
-dPV
-dPV
-dPz
-dPz
-dPz
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-kJH
-kJH
-kJH
-lnn
-lnn
-lnn
-auQ
-mVe
+puh
+ada
+ada
+iXK
+ada
+ada
+hfa
+hfa
+hfa
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xWK
+xWK
+xWK
+xDp
+xDp
+xDp
+dxc
+hbl
 abJ
-mVe
-mVe
-mVe
-fsP
-mVe
-mVe
-mVe
+hbl
+hbl
+hbl
+puh
+hbl
+hbl
+hbl
 ckv
-dPV
+ada
 dPV
 dPV
 jAZ
@@ -41420,33 +41218,33 @@ ymg
 sLi
 sLi
 sLi
-ymg
-ymg
-ymg
-dPV
-lnn
-fRr
-fRr
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-fRr
-lnn
-lnn
-apH
-lnn
-lnn
-vIK
-lnn
-lnn
-ymg
-ymg
-sLi
+kqj
+kqj
+kqj
+ada
+xDp
+pOn
+pOn
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+pOn
+xDp
+xDp
+kUT
+xDp
+xDp
+ach
+xDp
+xDp
+kqj
+kqj
+tdL
 ymg
 oIy
 fRr
@@ -41457,27 +41255,27 @@ fRr
 fRr
 fRr
 fRr
-dBR
-ylN
-ylN
+aaR
+rej
+rej
 dPz
 dPz
 dPz
 dPz
 dPz
-mPR
+oLW
 dDy
 gsc
 fzp
-rej
-kAA
+acN
+lHP
 cij
-rej
-rej
-rej
-rej
-rej
-rej
+acN
+acN
+acN
+acN
+acN
+acN
 cij
 eUz
 eUz
@@ -41503,49 +41301,49 @@ dPz
 dPz
 dPz
 dPz
-dPV
+ada
 ccX
 xWK
 xWK
 ccX
 joV
-fsP
-ylN
-fsP
+puh
+rej
+puh
 ccX
 xWK
 xWK
 ccX
-dPV
-dPV
-dPV
-dPz
-dPz
-dPz
-dPz
-lnn
-lnn
-lnn
-lnn
-kJH
+ada
+ada
+ada
+hfa
+hfa
+hfa
+hfa
+xDp
+xDp
+xDp
+xDp
+xWK
 abu
 mye
 aby
-kJH
-lnn
-lnn
-lnn
-fsP
-fsP
-fsP
-fsP
-fsP
-fsP
-fsP
-fsP
-fsP
-jPw
-lnn
+xWK
+xDp
+xDp
+xDp
+puh
+puh
+puh
+puh
+puh
+puh
+puh
+puh
+puh
+ckv
+xDp
 lnn
 lnn
 dPV
@@ -41577,33 +41375,33 @@ ymg
 sLi
 sLi
 sLi
-ymg
-fRr
-fRr
-fRr
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-fRr
-fRr
-fRr
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-dPV
-ymg
-sLi
+kqj
+pOn
+pOn
+pOn
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+pOn
+pOn
+pOn
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+ada
+kqj
+tdL
 ymg
 fRr
 fRr
@@ -41614,10 +41412,10 @@ ilZ
 ilZ
 fRr
 fRr
-fRr
-ylN
-ylN
-fRr
+pOn
+rej
+rej
+pOn
 dPz
 dPz
 dPz
@@ -41626,15 +41424,15 @@ cij
 fzp
 fzp
 fzp
-rej
-sWh
+acN
+qGr
 cij
-rej
-rej
-rej
-rej
-rej
-rej
+acN
+acN
+acN
+acN
+acN
+acN
 cij
 eUz
 eUz
@@ -41659,50 +41457,50 @@ dPz
 dPz
 dPz
 dPz
-dPV
-dPV
+ada
+ada
 xWK
 gbn
 rwQ
 env
-ylN
-ylN
-ylN
-fsP
+rej
+rej
+rej
+puh
 xWK
 jRf
 jRf
 xWK
-xfD
-dPV
-qwj
-dPV
-dPz
-dPz
-dPz
-dPz
-dPV
-lnn
-kJH
+wNi
+ada
+iPW
+ada
+hfa
+hfa
+hfa
+hfa
+ada
+xDp
+xWK
 abu
-aXS
-aXS
-aXS
-aXS
-kJH
-mVe
-mVe
-fsP
+uPQ
+uPQ
+uPQ
+uPQ
+xWK
+hbl
+hbl
+puh
 xSf
-mVe
-mVe
-mVe
-fsP
-mVe
-mVe
-mVe
+hbl
+hbl
+hbl
+puh
+hbl
+hbl
+hbl
 mMu
-lnn
+xDp
 lnn
 lnn
 lnn
@@ -41734,33 +41532,33 @@ ymg
 sLi
 sLi
 sLi
-ymg
-lnn
-fRr
-fRr
-fRr
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-fRr
-fRr
-kJH
-kJH
-kJH
-kJH
-kJH
-lnn
-lnn
-lnn
-lnn
-dPV
-ymg
-sLi
+kqj
+xDp
+pOn
+pOn
+pOn
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+pOn
+pOn
+xWK
+xWK
+xWK
+xWK
+xWK
+xDp
+xDp
+xDp
+xDp
+ada
+kqj
+tdL
 ymg
 fRr
 ilZ
@@ -41771,27 +41569,27 @@ fRr
 fRr
 fRr
 fsP
-fsP
-ylN
-ylN
-fRr
-fRr
-fRr
+puh
+rej
+rej
+pOn
+pOn
+pOn
 dPz
 dPz
 cij
 fzp
 fzp
 qxX
-rej
-maz
+acN
+vKq
 cij
-rej
-rej
-rej
-rej
-rej
-rej
+acN
+acN
+acN
+acN
+acN
+acN
 cij
 eUz
 eUz
@@ -41814,52 +41612,52 @@ dPz
 dPz
 dPz
 dPz
-fRr
-lnn
-dPV
-dPV
+pOn
+xDp
+ada
+ada
 xWK
 gbn
 rwQ
 env
-ylN
-ylN
-ylN
-ylN
+rej
+rej
+rej
+rej
 jcR
 qyk
 qyk
 xWK
-xfD
-dPV
-dPV
-dPV
-dPV
-dPz
-dPz
-dPz
-dPz
-lnn
-kJH
+wNi
+ada
+ada
+ada
+ada
+hfa
+hfa
+hfa
+hfa
+xDp
+xWK
 mye
-abv
+kLK
 abw
 abz
-aXS
+uPQ
 wFo
-fsP
-fsP
-fsP
+puh
+puh
+puh
 bLq
-fsP
-fsP
-mVI
-fsP
-mVI
-fsP
-fsP
+puh
+puh
+cqq
+puh
+cqq
+puh
+puh
 bLq
-lnn
+xDp
 lnn
 lnn
 lnn
@@ -41891,34 +41689,34 @@ ymg
 sLi
 sLi
 sLi
-ymg
-ymg
-lnn
-fRr
-fRr
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-fRr
-fRr
-fRr
+kqj
+kqj
+xDp
+pOn
+pOn
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+pOn
+pOn
+pOn
 lRI
 mDW
 mDW
 nPi
-kJH
-lnn
-lnn
-lnn
-ooF
-dPV
+xWK
+xDp
+xDp
+xDp
+lsY
+ada
+kqj
+tdL
 ymg
-sLi
-ymg
 fRr
 ilZ
 ilZ
@@ -41926,29 +41724,29 @@ fRr
 fsP
 fsP
 fRr
-fRr
-fsP
-ilZ
-ylN
-ylN
-fRr
-ilZ
-fRr
-dBR
+pOn
+puh
+cuY
+rej
+rej
+pOn
+cuY
+pOn
+aaR
 dPz
 cij
-rej
+acN
 cij
 iRK
-rej
-rej
+acN
+acN
 cij
 iUV
-rej
-rej
-rej
-rej
-kAA
+acN
+acN
+acN
+acN
+lHP
 cij
 eUz
 eUz
@@ -41970,53 +41768,53 @@ dPz
 dPz
 dPz
 dPz
-fRr
-fRr
-fRr
-lnn
-dPV
+pOn
+pOn
+pOn
+xDp
+ada
 ccX
 xWK
 xWK
 ccX
-fsP
-fsP
-ylN
-ylN
+puh
+puh
+rej
+rej
 ccX
 xWK
 xWK
 ccX
-xfD
-dPV
-dPV
-omo
-lnn
-dPV
-dPz
-dPz
-dPz
-lnn
-kJH
+wNi
+ada
+ada
+uMb
+xDp
+ada
+hfa
+hfa
+hfa
+xDp
+xWK
 abu
-aXS
-aXS
-aXS
-aXS
-kJH
-fsP
-fsP
-fsP
+uPQ
+uPQ
+uPQ
+uPQ
+xWK
+puh
+puh
+puh
 bLq
 jem
-iPW
-iPW
+cij
+cij
 eik
-iPW
-iPW
+cij
+cij
 rbz
 bLq
-lnn
+xDp
 lnn
 lnn
 lnn
@@ -42048,33 +41846,33 @@ ymg
 sLi
 sLi
 sLi
-ymg
-ymg
-lnn
-lnn
-fRr
-fRr
-lnn
-ooF
-lnn
-lnn
-lnn
-dPV
+kqj
+kqj
+xDp
+xDp
+pOn
+pOn
+xDp
+lsY
+xDp
+xDp
+xDp
+ada
 xXs
-fRr
-fRr
-kJH
+pOn
+pOn
+xWK
 mDW
 psv
 mDW
-kJH
-lnn
-lnn
-apH
-lnn
-dPV
-ymg
-sLi
+xWK
+xDp
+xDp
+kUT
+xDp
+ada
+kqj
+tdL
 ymg
 fsP
 fRr
@@ -42083,18 +41881,18 @@ fRr
 fRr
 fsP
 fRr
-fRr
-ilZ
-ilZ
-ylN
-ylN
-fRr
-fRr
-fRr
-fRr
-fRr
-cij
+pOn
+cuY
+cuY
 rej
+rej
+pOn
+pOn
+pOn
+pOn
+pOn
+cij
+acN
 cij
 cij
 cij
@@ -42126,54 +41924,54 @@ jMT
 dPz
 dPz
 dPz
-fRr
-fRr
-fRr
-fRr
-dPV
-dPV
-dPV
-dPV
-dPV
-dPV
-fsP
-ylN
-ylN
-ylN
-fsP
-fsP
-fsP
+pOn
+pOn
+pOn
+pOn
+ada
+ada
+ada
+ada
+ada
+ada
+puh
+rej
+rej
+rej
+puh
+puh
+puh
 hnK
-fsP
-dPV
-dPV
-dPV
-ooF
-dPV
-dPV
-dPz
-dPV
-ooF
-lnn
-kJH
+puh
+ada
+ada
+ada
+lsY
+ada
+ada
+hfa
+ada
+lsY
+xDp
+xWK
 abu
 mye
 abA
-kJH
+xWK
 abB
-mVe
-fsP
-fsP
-mVe
-iPW
+hbl
+puh
+puh
+hbl
+cij
 cBH
 srT
 hHC
 srT
 hSx
-iPW
-lnn
-lnn
+cij
+xDp
+xDp
 lnn
 lnn
 lnn
@@ -42205,33 +42003,33 @@ ymg
 sLi
 sLi
 sLi
-ymg
-ymg
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-dPV
-fRr
-fRr
-fRr
-kJH
+kqj
+kqj
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+ada
+pOn
+pOn
+pOn
+xWK
 oNP
 mDW
 mDW
-kJH
-lnn
-lnn
-lnn
-lnn
-dPV
-ymg
-sLi
+xWK
+xDp
+xDp
+xDp
+xDp
+ada
+kqj
+tdL
 ymg
 fsP
 fsP
@@ -42240,16 +42038,16 @@ vOy
 fRr
 fRr
 fRr
-fRr
-fRr
-fRr
-ylN
-ylN
-fsP
-ilZ
-fRr
-fRr
-fRr
+pOn
+pOn
+pOn
+rej
+rej
+puh
+cuY
+pOn
+pOn
+pOn
 cij
 cpp
 cij
@@ -42282,55 +42080,55 @@ dPz
 dPz
 dPz
 dPz
-fRr
-fRr
-fRr
-dPV
-fRr
-fRr
-dPV
-dPV
-dPV
+pOn
+pOn
+pOn
+ada
+pOn
+pOn
+ada
+ada
+ada
 scg
-dPV
-fsP
-ylN
-ylN
-ylN
+ada
+puh
+rej
+rej
+rej
 joV
-fsP
-fsP
-fsP
-fsP
-dPV
-dPV
-dPV
-lnn
-dPV
-dPV
-dPV
-dPV
-lnn
-lnn
-dPV
-kJH
-kJH
-kJH
-mVe
-fRr
-fRr
-fsP
-fsP
-mVe
+puh
+puh
+puh
+puh
+ada
+ada
+ada
+xDp
+ada
+ada
+ada
+ada
+xDp
+xDp
+ada
+xWK
+xWK
+xWK
+hbl
+pOn
+pOn
+puh
+puh
+hbl
 rUz
 aJv
 hSx
 hHC
 hUu
 ulz
-iPW
-lnn
-lnn
+cij
+xDp
+xDp
 lnn
 lnn
 lnn
@@ -42362,33 +42160,33 @@ ymg
 sLi
 sLi
 uGz
-ymg
-ymg
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-fRr
+kqj
+kqj
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+pOn
 xXs
-fRr
-fRr
-kJH
-kJH
-kJH
+pOn
+pOn
+xWK
+xWK
+xWK
 lRI
-kJH
-lnn
-lnn
-lnn
-lnn
-dPV
-ymg
-sLi
+xWK
+xDp
+xDp
+xDp
+xDp
+ada
+kqj
+tdL
 ymg
 ymg
 fsP
@@ -42397,18 +42195,18 @@ fRr
 fRr
 sIJ
 fRr
-fRr
-fRr
-fsP
-ylN
-ylN
-fsP
-fsP
-fRr
-fRr
-fRr
-fRr
-fRr
+pOn
+pOn
+puh
+rej
+rej
+puh
+puh
+pOn
+pOn
+pOn
+pOn
+pOn
 dPz
 dPz
 dPz
@@ -42438,56 +42236,56 @@ dPz
 dPz
 dPz
 dPz
-fRr
-fRr
-fRr
-lnn
-dPV
-fRr
-ilZ
-ilZ
-dPV
-dPV
+pOn
+pOn
+pOn
+xDp
+ada
+pOn
+cuY
+cuY
+ada
+ada
 scg
-xfD
-fsP
+wNi
+puh
 ras
-ylN
-ylN
-ylN
-fsP
+rej
+rej
+rej
+puh
 joV
 hnK
-fsP
-xfD
-dPV
-dPV
-dPV
-dPV
-dPV
-dPV
-dPV
-dPV
-lnn
-apH
-cQd
+puh
+wNi
+ada
+ada
+ada
+ada
+ada
+ada
+ada
+ada
+xDp
+kUT
+lyP
 hOv
-aXS
-fsP
-fRr
-fRr
-cdc
-fsP
-fsP
-iPW
+acL
+puh
+pOn
+pOn
+jHG
+puh
+puh
+cij
 oCY
 hSx
 hHC
 hSx
 hSx
-iPW
-fRr
-fRr
+cij
+pOn
+pOn
 lnn
 lnn
 lnn
@@ -42519,54 +42317,54 @@ ymg
 sLi
 sLi
 uGz
-ymg
-ymg
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-fRr
-fRr
-fRr
-fRr
+kqj
+kqj
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+pOn
+pOn
+pOn
+pOn
 kaW
 rtr
-fRr
-fRr
-fRr
-ooF
-lnn
-lnn
+pOn
+pOn
+pOn
+lsY
+xDp
+xDp
 gjU
-dPV
-ymg
-uSj
-sLi
+ada
+kqj
+kSI
+tdL
 ymg
 fsP
 fRr
 ilZ
 fRr
 fRr
-fRr
-fRr
-fsP
-fsP
-ylN
-ylN
-fsP
-fsP
-fsP
-ilZ
-fRr
-fRr
-fRr
-fRr
+pOn
+pOn
+puh
+puh
+rej
+rej
+puh
+puh
+puh
+cuY
+pOn
+pOn
+pOn
+pOn
 dPz
 dPz
 dPz
@@ -42595,56 +42393,56 @@ dPz
 dPz
 dPz
 dPz
-fRr
-fRr
-fRr
-dPV
-dPV
-lnn
-fRr
-ilZ
-dPV
-dPV
-dPV
-dPV
-fsP
-ylN
-ylN
-ylN
-ylN
+pOn
+pOn
+pOn
+ada
+ada
+xDp
+pOn
+cuY
+ada
+ada
+ada
+ada
+puh
+rej
+rej
+rej
+rej
 ccX
 xWK
 xWK
 xWK
 ccX
-lnn
-dPV
-dPV
+xDp
+ada
+ada
 pVd
-dPV
-dPV
-dPV
-dPV
-lnn
-lnn
-cQd
-aXS
-aXS
-fsP
-mVe
-fRr
-lnn
-mVe
-fsP
+ada
+ada
+ada
+ada
+xDp
+xDp
+lyP
+acL
+acL
+puh
+hbl
+pOn
+xDp
+hbl
+puh
 xhS
 hSx
 hSx
 pVi
 hSx
 hSx
-iPW
-fRr
-fRr
+cij
+pOn
+pOn
 ilZ
 ilZ
 lnn
@@ -42676,56 +42474,56 @@ sLi
 sLi
 sLi
 uGz
-ymg
-ymg
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-dPV
-fRr
-fRr
+kqj
+kqj
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+ada
+pOn
+pOn
 xXs
-fRr
-fRr
+pOn
+pOn
 clC
 clC
-fRr
-fRr
-fRr
-lnn
-lnn
-lnn
-lnn
-dPV
+pOn
+pOn
+pOn
+xDp
+xDp
+xDp
+xDp
+ada
+kqj
+kqj
+tdL
 ymg
-ymg
-sLi
-ymg
 fsP
 fRr
 fRr
 fRr
-fRr
-ilZ
-fRr
-fsP
-fsP
-ylN
-ylN
-nPK
-fsP
-fsP
-fRr
-fRr
-fRr
-fRr
-fRr
-fRr
-ilw
+pOn
+cuY
+pOn
+puh
+puh
+rej
+rej
+moC
+puh
+puh
+pOn
+pOn
+pOn
+pOn
+pOn
+pOn
+bzF
 dPz
 dPz
 ylN
@@ -42752,56 +42550,56 @@ dPz
 dPz
 dPz
 dPz
-fRr
-fRr
-fRr
-dPV
-lnn
-lnn
-fRr
-fRr
-dPV
+pOn
+pOn
+pOn
+ada
+xDp
+xDp
+pOn
+pOn
+ada
 vMx
-lnn
-xfD
-dPV
-ylN
-ylN
-ylN
-ylN
+xDp
+wNi
+ada
+rej
+rej
+rej
+rej
 xWK
 jRf
 qyk
 qyk
 xWK
-lnn
-dPV
-dPV
-dPV
-abb
-dPV
-dPV
-dPV
-lnn
-lnn
-cQd
+xDp
+ada
+ada
+ada
+iXK
+ada
+ada
+ada
+xDp
+xDp
+lyP
 abx
-aXS
-fsP
-fsP
-fRr
-mVe
-fsP
-fsP
-iPW
+acL
+puh
+puh
+pOn
+hbl
+puh
+puh
+cij
 xgG
 hSx
 lRw
 hjJ
 vuV
-iPW
-fRr
-fRr
+cij
+pOn
+pOn
 fRr
 lnn
 lnn
@@ -42832,57 +42630,57 @@ ymg
 sLi
 sLi
 uGz
+kqj
+kqj
+xDp
+xDp
+xDp
+lsY
+xDp
+xDp
+xDp
+ada
+ada
+pOn
+pOn
+pOn
+pOn
+pOn
+pOn
+pOn
+pOn
+pOn
+pOn
+xDp
+awH
+xDp
+xDp
+ada
+ada
+kqj
+tdL
 ymg
 ymg
-lnn
-lnn
-lnn
-ooF
-lnn
-lnn
-lnn
-dPV
-dPV
 fRr
 fRr
 fRr
-fRr
-fRr
-fRr
-fRr
-fRr
-fRr
-fRr
-lnn
-ulc
-lnn
-lnn
-dPV
-dPV
-ymg
-sLi
-ymg
-ymg
-fRr
-fRr
-fRr
-fRr
-fRr
-fRr
-fsP
-fsP
-ylN
-ylN
+pOn
+pOn
+pOn
+puh
+puh
+rej
+rej
 aae
-ylN
-fsP
-fsP
-fRr
-fRr
-fRr
-mPR
-bxn
-bxn
+rej
+puh
+puh
+pOn
+pOn
+pOn
+san
+vUL
+vUL
 dPz
 ylN
 ylN
@@ -42909,56 +42707,56 @@ biI
 dPz
 dPz
 dPz
-fRr
-ilZ
-fRr
-dPV
-lnn
-cdc
-lnn
-dPV
-fRr
+pOn
+cuY
+pOn
+ada
+xDp
+jHG
+xDp
+ada
+pOn
 scg
-lnn
-dPV
-xfD
-fsP
-ylN
-ylN
-ylN
+xDp
+ada
+wNi
+puh
+rej
+rej
+rej
 jcR
 qyk
 qyk
 jRf
 xWK
-lnn
-dPV
-dPV
-dPV
-dPV
-dPV
-dPV
-dPV
-lnn
-lnn
-lnn
-cQd
-cQd
-mVe
-fsP
-fsP
-fsP
-fsP
-fsP
+xDp
+ada
+ada
+ada
+ada
+ada
+ada
+ada
+xDp
+xDp
+xDp
+lyP
+lyP
+hbl
+puh
+puh
+puh
+puh
+puh
 rUz
 rEe
 egn
 lRw
-aKS
-rDz
-iPW
-fRr
-fRr
+fOB
+sPC
+cij
+pOn
+pOn
 fRr
 fRr
 lnn
@@ -42989,53 +42787,53 @@ ymg
 sLi
 sLi
 uGz
-ymg
-ymg
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-dPV
-fRr
-fRr
-fRr
+kqj
+kqj
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+ada
+pOn
+pOn
+pOn
 xXs
-dPV
-dPV
-dPV
-fRr
-fRr
-fRr
-fRr
-lnn
-lnn
-lnn
-lnn
-loN
-dPV
-ymg
-uSj
-sLi
+ada
+ada
+ada
+pOn
+pOn
+pOn
+pOn
+xDp
+xDp
+xDp
+xDp
+rvZ
+ada
+kqj
+kSI
+tdL
 ymg
 dBR
 fRr
 fRr
-fRr
-vOy
-fRr
-fRr
-fsP
+pOn
+qXZ
+pOn
+pOn
+puh
 aae
-ylN
-ylN
-ylN
-ylN
-fsP
-fRr
-fRr
+rej
+rej
+rej
+rej
+puh
+pOn
+pOn
 pFm
 hnK
 fsP
@@ -43066,56 +42864,56 @@ dPz
 dPz
 dPz
 dPz
-fRr
-fRr
-lnn
-dPV
-lnn
-lnn
-dXm
-lnn
-lnn
-lnn
+pOn
+pOn
+xDp
+ada
+xDp
+xDp
+pSx
+xDp
+xDp
+xDp
 vMx
-dPV
-fsP
-fsP
-ylN
-ylN
+ada
+puh
+puh
+rej
+rej
 joV
 ccX
 xWK
 xWK
 xWK
 ccX
-dPV
-lnn
-omo
-abb
-dPV
-dPV
-dPV
-dPV
-lnn
-lnn
-lnn
-lnn
-dPV
-dPV
-mVe
-fsP
-fsP
-fsP
-fsP
-iPW
+ada
+xDp
+uMb
+iXK
+ada
+ada
+ada
+ada
+xDp
+xDp
+xDp
+xDp
+ada
+ada
+hbl
+puh
+puh
+puh
+puh
+cij
 rEe
 dWc
 lRw
 bdY
 ehy
-iPW
-lnn
-fRr
+cij
+xDp
+pOn
 tLJ
 fRr
 lnn
@@ -43146,54 +42944,54 @@ ymg
 sLi
 sLi
 uGz
+kqj
+kqj
+pOn
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+ada
+pOn
+pOn
+pOn
+ada
+ada
+ada
+ada
+pOn
+pOn
+pOn
+pOn
+xDp
+xDp
+xDp
+xDp
+ada
+ada
+kqj
+kqj
+tdL
 ymg
-ymg
-fRr
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-dPV
 fRr
 fRr
-fRr
-dPV
-dPV
-dPV
-dPV
-fRr
-fRr
-fRr
-fRr
-lnn
-lnn
-lnn
-lnn
-dPV
-dPV
-ymg
-ymg
-sLi
-ymg
-fRr
-fRr
-fRr
-ilZ
-fsP
-fRr
-fRr
-fsP
-ylN
-ylN
-ylN
+pOn
+cuY
+puh
+pOn
+pOn
+puh
+rej
+rej
+rej
 aae
-ylN
-ylN
+rej
+rej
 aae
-ylN
-fRr
+rej
+pOn
 uaF
 fsP
 enF
@@ -43222,57 +43020,57 @@ dPz
 dPz
 dPz
 dPz
-fRr
-fRr
-lnn
-lnn
-lnn
-lnn
-lnn
-dPV
-lnn
-dPV
-lnn
+pOn
+pOn
+xDp
+xDp
+xDp
+xDp
+xDp
+ada
+xDp
+ada
+xDp
 scg
-fsP
-fsP
-fsP
-ylN
-ylN
-fsP
+puh
+puh
+puh
+rej
+rej
+puh
 hXE
-dPV
-dPV
-lnn
-lnn
-dPV
-lnn
-lnn
-lnn
-abb
-dPV
-dPV
-dPV
-vIK
-lnn
-ooF
-lnn
-dPV
-fRr
+ada
+ada
+xDp
+xDp
+ada
+xDp
+xDp
+xDp
+iXK
+ada
+ada
+ada
+ach
+xDp
+lsY
+xDp
+ada
+pOn
 joV
-fsP
-fsP
-mVe
+puh
+puh
+hbl
 rJY
-lnn
-iPW
-iPW
-iPW
-iPW
-iPW
-lnn
-lnn
-lnn
+xDp
+cij
+cij
+cij
+cij
+cij
+xDp
+xDp
+xDp
 fRr
 lnn
 lnn
@@ -43303,54 +43101,54 @@ lnn
 sLi
 sLi
 sLi
+kqj
+xDp
+pOn
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+ada
+pOn
+pOn
+pOn
+ada
+ada
+ada
+ada
+xDp
+xDp
+pOn
+pOn
+ada
+ada
+ada
+ach
+ada
+wNi
+ada
+kqj
+tdL
 ymg
-lnn
-fRr
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-dPV
 fRr
 fRr
-fRr
-dPV
-dPV
-dPV
-dPV
-lnn
-lnn
-fRr
-fRr
-dPV
-dPV
-dPV
-vIK
-dPV
-xfD
-dPV
-ymg
-sLi
-ymg
-fRr
-fRr
-fRr
-fsP
-fsP
-ilZ
-fRr
-fRr
-fsP
+pOn
+puh
+puh
+cuY
+pOn
+pOn
+puh
 aae
 aae
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
+rej
+rej
+rej
+rej
+rej
+rej
 kEx
 ylN
 ylN
@@ -43378,64 +43176,64 @@ dPz
 dPz
 dPz
 dPz
-fRr
-fRr
-fRr
-lnn
-dPV
-qal
-lnn
-lnn
-dPV
-dPV
-fRr
-lnn
+pOn
+pOn
+pOn
+xDp
+ada
+dDS
+xDp
+xDp
+ada
+ada
+pOn
+xDp
 ccX
 jcR
 jcR
 ccX
-ylN
-ylN
-fsP
+rej
+rej
+puh
 hXE
-dPV
-dPV
-lnn
-dPV
-dPV
-lnn
-lnn
-lnn
-dPV
-dPV
-dPV
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-mVe
-fsP
-fsP
-mVe
-mVe
-lnn
-lnn
+ada
+ada
+xDp
+ada
+ada
+xDp
+xDp
+xDp
+ada
+ada
+ada
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+hbl
+puh
+puh
+hbl
+hbl
+xDp
+xDp
+xDp
+xDp
+xDp
+lsY
+xDp
+xDp
+xDp
+xDp
 lnn
 lnn
 lnn
 ooF
 lnn
 lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-ooF
-lnn
-lnn
 dPV
 dPV
 dPV
@@ -43460,54 +43258,54 @@ lnn
 sLi
 sLi
 sLi
-ymg
-lnn
-ilZ
-dPV
-dPV
-dPV
-dPV
-abb
-dPV
-fRr
-fRr
-fRr
-dPV
-dPV
-dPV
-dPV
-dPV
-apH
-lnn
-fRr
-fRr
-fRr
-dPV
-dPV
-lnn
-dPV
-dPV
-dPV
-ymg
-sLi
+kqj
+xDp
+cuY
+ada
+ada
+ada
+ada
+iXK
+ada
+pOn
+pOn
+pOn
+ada
+ada
+ada
+ada
+ada
+kUT
+xDp
+pOn
+pOn
+pOn
+ada
+ada
+xDp
+ada
+ada
+ada
+kqj
+tdL
 ymg
 fRr
 fRr
-ilZ
-fsP
-fRr
-fRr
-fRr
-mvK
+cuY
+puh
+pOn
+pOn
+pOn
+fcm
 abr
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
+rej
+rej
+rej
+rej
+rej
+rej
 aae
-ylN
+rej
 kEx
 ylN
 ylN
@@ -43534,58 +43332,58 @@ dPz
 dPz
 dPz
 dPz
-fRr
-fRr
-fRr
-fRr
-dPV
-lnn
-lnn
-lnn
-dPV
-dPV
-ilZ
-ilZ
-fRr
+pOn
+pOn
+pOn
+pOn
+ada
+xDp
+xDp
+xDp
+ada
+ada
+cuY
+cuY
+pOn
 xWK
 qyk
 qyk
 xWK
-ylN
-ylN
-fsP
-dPV
-dPV
-dPV
-lnn
-dPV
-dPV
-pHC
-lnn
-dPV
-dPV
-dPV
-dPV
-lnn
-lnn
-lnn
-lnn
-lnn
-mVe
-fsP
-fsP
-fsP
-mVe
-mVe
-lnn
-lnn
-lnn
-uXC
-lnn
-lnn
-lnn
-lnn
-fRr
+rej
+rej
+puh
+ada
+ada
+ada
+xDp
+ada
+ada
+wxW
+xDp
+ada
+ada
+ada
+ada
+xDp
+xDp
+xDp
+xDp
+xDp
+hbl
+puh
+puh
+puh
+hbl
+hbl
+xDp
+xDp
+xDp
+pQw
+xDp
+xDp
+xDp
+xDp
+pOn
 lnn
 lnn
 lnn
@@ -43617,54 +43415,54 @@ lnn
 sLi
 sLi
 sLi
+kqj
+xDp
+pOn
+ada
+ada
+ada
+ada
+ada
+ada
+pOn
+pOn
+ada
+ada
+ada
+ada
+aaG
+ada
+ada
+ada
+pOn
+pOn
+pOn
+ada
+ada
+xDp
+ada
+ada
+ada
+kqj
+tdL
 ymg
-lnn
-fRr
-dPV
-dPV
-dPV
-dPV
-dPV
-dPV
-fRr
-fRr
-dPV
-dPV
-dPV
-dPV
-jzM
-dPV
-dPV
-dPV
-fRr
-fRr
-fRr
-dPV
-dPV
-lnn
-dPV
-dPV
-dPV
 ymg
-sLi
-ymg
-ymg
-ilZ
-ilZ
-fRr
-fRr
-fRr
-fRr
-fRr
-ylN
-ylN
-ylN
-ylN
-ylN
+cuY
+cuY
+pOn
+pOn
+pOn
+pOn
+pOn
+rej
+rej
+rej
+rej
+rej
 aae
-ylN
-ylN
-ylN
+rej
+rej
+rej
 kEx
 fsP
 fsP
@@ -43689,58 +43487,58 @@ dPz
 dPz
 dPz
 dPz
-fRr
-fRr
-fRr
-fRr
-fRr
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-ilZ
-fRr
-fRr
+pOn
+pOn
+pOn
+pOn
+pOn
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+cuY
+pOn
+pOn
 xWK
 wvf
 qyk
 xWK
-ylN
-ylN
-dPV
-dPV
+rej
+rej
+ada
+ada
 hXE
-lnn
-lnn
-dPV
-dPV
-dPV
-dPV
-dPV
-dPV
-dPV
-dPV
-ooF
-lnn
-lnn
-lnn
-mVe
-fsP
-fsP
-fsP
-fsP
+xDp
+xDp
+ada
+ada
+ada
+ada
+ada
+ada
+ada
+ada
+lsY
+xDp
+xDp
+xDp
+hbl
+puh
+puh
+puh
+puh
 ely
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
 lnn
 fRr
 ilZ
@@ -43774,54 +43572,54 @@ ooF
 sLi
 sLi
 sLi
-ymg
-lnn
-fRr
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-fRr
-fRr
-fRr
-lnn
-fRr
-lnn
-dPV
-dPV
-dPV
-dPV
-dPV
-fRr
-dPV
-dPV
-abb
-lnn
-dPV
-dPV
-dPV
-ymg
-uSj
-sLi
-ymg
-fRr
-fRr
-fRr
-ilZ
-fRr
-fRr
-fsP
-ylN
+kqj
+xDp
+pOn
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+pOn
+pOn
+pOn
+xDp
+pOn
+xDp
+ada
+ada
+ada
+ada
+ada
+pOn
+ada
+ada
+iXK
+xDp
+ada
+ada
+ada
+kqj
+kSI
+tdL
+kqj
+pOn
+pOn
+pOn
+cuY
+pOn
+pOn
+puh
+rej
 aae
-ylN
+rej
 aae
-ylN
-ylN
-ylN
-ylN
-fRr
+rej
+rej
+rej
+rej
+pOn
 sML
 vZg
 fRr
@@ -43845,58 +43643,58 @@ jMT
 dPz
 dPz
 dPz
-fRr
-fRr
-fRr
-fRr
-dPV
-lnn
-lnn
-lnn
-lnn
-lnn
-dPV
-fRr
-fRr
-ilZ
-fRr
-fRr
+pOn
+pOn
+pOn
+pOn
+ada
+xDp
+xDp
+xDp
+xDp
+xDp
+ada
+pOn
+pOn
+cuY
+pOn
+pOn
 xWK
 jao
 qyk
 xWK
-ylN
-ylN
-dPV
-lnn
+rej
+rej
+ada
+xDp
 hXE
-lnn
-lnn
-dPV
-dPV
-dPV
-lnn
-dPV
-dPV
-dPV
-dPV
-lnn
-lnn
-lnn
-mVe
-fsP
-fsP
-fsP
-mVe
-mVe
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-ilZ
-ilZ
+xDp
+xDp
+ada
+ada
+ada
+xDp
+ada
+ada
+ada
+ada
+xDp
+xDp
+xDp
+hbl
+puh
+puh
+puh
+hbl
+hbl
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+cuY
+cuY
 fRr
 lnn
 lnn
@@ -43931,53 +43729,53 @@ lnn
 sLi
 sLi
 sLi
-ymg
-ymg
-lnn
-lnn
-lnn
-lnn
-apH
-lnn
-fRr
-ilZ
-fRr
-fRr
-lnn
-lnn
-fRr
-fRr
-lnn
-lnn
-lnn
-lnn
-fRr
-lnn
-lnn
-lnn
-lnn
-dPV
-cIa
-dPV
-ymg
-ymg
-sLi
-ymg
-fRr
-fRr
-fRr
-fRr
-fRr
-fRr
-fsP
-fsP
-ylN
+kqj
+kqj
+xDp
+xDp
+xDp
+xDp
+kUT
+xDp
+pOn
+cuY
+pOn
+pOn
+xDp
+xDp
+pOn
+pOn
+xDp
+xDp
+xDp
+xDp
+pOn
+xDp
+xDp
+xDp
+xDp
+ada
+jrE
+ada
+kqj
+kqj
+tdL
+kqj
+pOn
+pOn
+pOn
+pOn
+pOn
+pOn
+puh
+puh
+rej
 abs
-ylN
-ylN
+rej
+rej
 joV
-fRr
-fRr
+pOn
+pOn
 pFm
 hnK
 wYI
@@ -44001,59 +43799,59 @@ jMT
 jMT
 dPz
 dPz
-omo
-fRr
-fRr
-fRr
-fRr
-dPV
-ilZ
-fRr
-fRr
-fRr
-fRr
-ilZ
-fRr
-fRr
-fRr
-fRr
-dPV
+uMb
+pOn
+pOn
+pOn
+pOn
+ada
+cuY
+pOn
+pOn
+pOn
+pOn
+cuY
+pOn
+pOn
+pOn
+pOn
+ada
 xWK
 wvf
 jao
 xWK
-ylN
-ylN
-dPV
-lnn
-dPV
-dPV
-lnn
-dPV
-bOa
-omo
-lnn
-dPV
-abb
-dPV
-lnn
-lnn
-lnn
-fRr
-fsP
-fsP
-fsP
-mVe
-mVe
-lnn
-lnn
-lnn
-lnn
-fRr
-fRr
-fRr
-fRr
-fRr
+rej
+rej
+ada
+xDp
+ada
+ada
+xDp
+ada
+cHF
+uMb
+xDp
+ada
+iXK
+ada
+xDp
+xDp
+xDp
+pOn
+puh
+puh
+puh
+hbl
+hbl
+xDp
+xDp
+xDp
+xDp
+pOn
+pOn
+pOn
+pOn
+pOn
 lnn
 fRr
 lnn
@@ -44088,55 +43886,55 @@ lnn
 sLi
 sLi
 sLi
-ymg
-ymg
-lnn
-lnn
-lnn
-uXC
-lnn
-lnn
-fRr
-fRr
-ilZ
-lnn
-lnn
-lnn
-fRr
-fRr
-fRr
+kqj
+kqj
+xDp
+xDp
+xDp
+pQw
+xDp
+xDp
+pOn
+pOn
+cuY
+xDp
+xDp
+xDp
+pOn
+pOn
+pOn
 xeq
-lnn
+xDp
 xeq
-fRr
-abb
-lnn
-lnn
-lnn
-dPV
-dPV
-dPV
-dPV
-ymg
-sLi
-ymg
-fRr
-ilZ
-fRr
-fRr
-fRr
-fRr
-fsP
-ylN
-ylN
-ylN
-fsP
-fsP
-fsP
-fRr
-fRr
-fRr
-mPR
+pOn
+iXK
+xDp
+xDp
+xDp
+ada
+ada
+ada
+ada
+kqj
+tdL
+kqj
+pOn
+cuY
+pOn
+pOn
+pOn
+pOn
+puh
+rej
+rej
+rej
+puh
+puh
+puh
+pOn
+pOn
+pOn
+san
 nPK
 fRr
 mVe
@@ -44158,59 +43956,59 @@ vTH
 jMT
 dPz
 dPz
-ilZ
-ilZ
-dPV
-lnn
-lnn
-fRr
-ilZ
-fRr
-fRr
-fRr
-fRr
-fRr
-fRr
-lnn
-fRr
-fRr
-dPV
+cuY
+cuY
+ada
+xDp
+xDp
+pOn
+cuY
+pOn
+pOn
+pOn
+pOn
+pOn
+pOn
+xDp
+pOn
+pOn
+ada
 ccX
 xWK
 xWK
 ccX
-ylN
-omo
-omo
-dPV
+rej
+uMb
+uMb
+ada
 hXE
-lnn
-lnn
-lnn
-bOa
-omo
-lnn
-dPV
-dPV
-dPV
-lnn
-lnn
-fRr
-mVe
-fsP
-fsP
-fsP
-mVe
-lnn
-lnn
-lnn
-lnn
-ilZ
-fRr
-fRr
-fRr
-tLJ
-fRr
+xDp
+xDp
+xDp
+cHF
+uMb
+xDp
+ada
+ada
+ada
+xDp
+xDp
+pOn
+hbl
+puh
+puh
+puh
+hbl
+xDp
+xDp
+xDp
+xDp
+cuY
+pOn
+pOn
+pOn
+cOy
+pOn
 fRr
 fRr
 fRr
@@ -44245,55 +44043,55 @@ bOa
 sLi
 sLi
 sLi
-ymg
-ymg
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-fRr
-ilZ
-fRr
-dPV
-dPV
-dPV
-fRr
-fRr
-fRr
+kqj
+kqj
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+pOn
+cuY
+pOn
+ada
+ada
+ada
+pOn
+pOn
+pOn
 wku
 ppV
 oQe
-fRr
-dPV
-lnn
-lnn
-lnn
-lnn
-dPV
-dPV
-dPV
-ymg
-sLi
-ymg
-fRr
-fRr
-fRr
-fRr
-ilZ
-fRr
-fsP
-ylN
-ylN
-nPK
-fsP
-fRr
-fRr
-fRr
-fRr
-fRr
-bxn
+pOn
+ada
+xDp
+xDp
+xDp
+xDp
+ada
+ada
+ada
+kqj
+tdL
+kqj
+pOn
+pOn
+pOn
+pOn
+cuY
+pOn
+puh
+rej
+rej
+moC
+puh
+pOn
+pOn
+pOn
+pOn
+pOn
+vUL
 fRr
 fRr
 mVe
@@ -44315,59 +44113,59 @@ vTH
 jMT
 dPz
 dPz
-cQd
-cQd
-cQd
-cQd
-cQd
-cQd
-fRr
-fRr
-fRr
-dPV
-fRr
-fRr
-dPV
-dPV
-fRr
-dPV
-dPV
-dPV
-dPV
-dPV
-ylN
-ylN
-dPV
-omo
+ccX
+ccX
+ccX
+ccX
+ccX
+ccX
+pOn
+pOn
+pOn
+ada
+pOn
+pOn
+ada
+ada
+pOn
+ada
+ada
+ada
+ada
+ada
+rej
+rej
+ada
+uMb
 lDW
 jMa
-dPV
-dPV
-lnn
-lnn
-dPV
-lnn
-lnn
-dPV
-dPV
-lnn
-lnn
-mVe
-mVe
-fsP
-fsP
-mVe
-ooF
-dPV
-dPV
-lnn
-lnn
-lnn
-ilZ
-fRr
-fRr
-fRr
-fRr
+ada
+ada
+xDp
+xDp
+ada
+xDp
+xDp
+ada
+ada
+xDp
+xDp
+hbl
+hbl
+puh
+puh
+hbl
+lsY
+ada
+ada
+xDp
+xDp
+xDp
+cuY
+pOn
+pOn
+pOn
+pOn
 lnn
 tLJ
 fRr
@@ -44402,55 +44200,55 @@ lnn
 sLi
 sLi
 sLi
-ymg
-ymg
-lnn
-lnn
-lnn
-lnn
+kqj
+kqj
+xDp
+xDp
+xDp
+xDp
 opb
 wzC
 wzC
 wzC
 fNu
-dPV
-dPV
-loN
-dPV
-fRr
-fRr
+ada
+ada
+rvZ
+ada
+pOn
+pOn
 kwg
-qYz
+yaE
 oQe
-fRr
-abV
-abV
-abV
-abV
-abV
-dPV
-dPV
-xfD
-ymg
-sLi
-ymg
-fRr
+pOn
+yaE
+yaE
+yaE
+yaE
+yaE
+ada
+ada
+wNi
+kqj
+tdL
+kqj
+pOn
 uHt
 uHt
-fJU
-fJU
-bxn
-bxn
-bxn
-ylN
-fsP
-fsP
-ilZ
-fRr
-fRr
-fRr
-fRr
-bxn
+jwv
+jwv
+lRw
+lRw
+lRw
+rej
+puh
+puh
+cuY
+pOn
+pOn
+pOn
+pOn
+vUL
 biI
 biI
 fRr
@@ -44472,59 +44270,59 @@ vTH
 jMT
 jMT
 dPz
-cQd
+ccX
 uSy
-kzW
+hHC
 rIC
 rIC
-cQd
-dPV
-fRr
-fRr
-dPV
-dPV
-dPV
-fRr
-dPV
-dPV
-pHC
-dPV
-dPV
-dPV
-dPV
-ylN
-ylN
-dPV
-dPV
-dPV
-dPV
-dPV
-lnn
-lnn
-dPV
-dPV
-dPV
-dPV
-abb
-lnn
-lnn
-mVe
-fsP
-fsP
-fsP
-mVe
-lnn
-lnn
-dPV
-dPV
-lnn
-lnn
-lnn
-lnn
-fRr
-fRr
-fRr
-lnn
+ccX
+ada
+pOn
+pOn
+ada
+ada
+ada
+pOn
+ada
+ada
+wxW
+ada
+ada
+ada
+ada
+rej
+rej
+ada
+ada
+ada
+ada
+ada
+xDp
+xDp
+ada
+ada
+ada
+ada
+iXK
+xDp
+xDp
+hbl
+puh
+puh
+puh
+hbl
+xDp
+xDp
+ada
+ada
+xDp
+xDp
+xDp
+xDp
+pOn
+pOn
+pOn
+xDp
 lnn
 dPu
 fRr
@@ -44559,55 +44357,55 @@ ymg
 uSj
 sLi
 sLi
-ymg
-ymg
-ymg
-lnn
-lnn
-lnn
+kqj
+kqj
+kqj
+xDp
+xDp
+xDp
 rJb
-aXS
-aXS
-aXS
-aXS
-dPV
-dPV
-dPV
-dPV
-fRr
-fRr
+acL
+acL
+acL
+acL
+ada
+ada
+ada
+ada
+pOn
+pOn
 abY
 abY
 abY
 abZ
 abZ
 kBJ
-bRO
-bRO
+acN
+acN
 vxu
-dPV
-dPV
-dPV
-ymg
-sLi
-ymg
-fRr
+ada
+ada
+ada
+kqj
+tdL
+kqj
+pOn
 tuX
-mhc
+abX
 xlj
 uHt
 rTM
 jYa
-bxn
-ylN
-ylN
-fRr
-fRr
-fRr
-fRr
-fRr
-biI
-ilw
+lRw
+rej
+rej
+pOn
+pOn
+pOn
+pOn
+pOn
+jSD
+bzF
 biI
 riU
 fRr
@@ -44629,59 +44427,59 @@ vTH
 jMT
 jMT
 dPz
-cQd
-kzW
-kzW
-kzW
-kzW
-cQd
-dPV
-dPV
-fRr
-fRr
-dPV
-dPV
-dPV
-dPV
-dPV
-fRr
-fRr
-lnn
-lnn
-dPV
-ylN
-ylN
-ylN
-dPV
-lnn
-dPV
-lnn
-lnn
-lnn
-dPV
-lnn
-lnn
-dPV
-lnn
-lnn
+ccX
+hHC
+hHC
+hHC
+hHC
+ccX
+ada
+ada
+pOn
+pOn
+ada
+ada
+ada
+ada
+ada
+pOn
+pOn
+xDp
+xDp
+ada
+rej
+rej
+rej
+ada
+xDp
+ada
+xDp
+xDp
+xDp
+ada
+xDp
+xDp
+ada
+xDp
+xDp
 ely
-fsP
-fsP
-fsP
-mVe
-lnn
-lnn
-lnn
-dPV
-cQd
-cQd
-cQd
+puh
+puh
+puh
+hbl
+xDp
+xDp
+xDp
+ada
+ccX
+ccX
+ccX
 lUQ
-cQd
-lnn
-lnn
-fRr
-lnn
+ccX
+xDp
+xDp
+pOn
+xDp
 lnn
 lnn
 lnn
@@ -44716,55 +44514,55 @@ ymg
 uSj
 sLi
 sLi
-ymg
-ymg
-ymg
-dPV
-dPV
-dPV
+kqj
+kqj
+kqj
+ada
+ada
+ada
 oUP
-aXS
-aXS
-aXS
+acL
+acL
+acL
 abv
-dPV
-dPV
-dPV
-lnn
-fRr
-fRr
+ada
+ada
+ada
+xDp
+pOn
+pOn
 abZ
 acc
 acc
 acc
 abY
 nMT
-ach
+kzw
 dIs
-abV
-dPV
-dPV
-dPV
-ymg
-sLi
-ymg
-ymg
+yaE
+ada
+ada
+ada
+kqj
+tdL
+kqj
+kqj
 tuX
-mhc
-mhc
+abX
+abX
 upU
 cQU
 wdy
 tuX
-ylN
-ylN
-fRr
-fRr
-fRr
-fRr
-biI
-biI
-mPR
+rej
+rej
+pOn
+pOn
+pOn
+pOn
+jSD
+jSD
+san
 biI
 fRr
 fRr
@@ -44786,60 +44584,60 @@ vTH
 jMT
 jMT
 dPz
-cQd
+ccX
 gag
-kzW
-kzW
-kzW
-cQd
-dPV
-dPV
-dPV
-ilZ
-fRr
-fRr
-dPV
-dPV
-fRr
-fRr
-fRr
-fRr
-dPV
-dPV
-mPR
+hHC
+hHC
+hHC
+ccX
+ada
+ada
+ada
+cuY
+pOn
+pOn
+ada
+ada
+pOn
+pOn
+pOn
+pOn
+ada
+ada
+san
 jIC
-ylN
-dPV
-lnn
-lnn
-abb
-lnn
-dPV
-dPV
-dPV
-dPV
-dPV
-lnn
-mVe
-fsP
-fsP
-fsP
-mVe
-lnn
-lnn
-lnn
-lnn
-cQd
-cQd
+rej
+ada
+xDp
+xDp
+iXK
+xDp
+ada
+ada
+ada
+ada
+ada
+xDp
+hbl
+puh
+puh
+puh
+hbl
+xDp
+xDp
+xDp
+xDp
+ccX
+ccX
 mzO
-xOC
+gbn
 bYw
-cQd
-cQd
-mVe
-lnn
-lnn
-lnn
+ccX
+ccX
+hbl
+xDp
+xDp
+xDp
 lnn
 uXC
 lnn
@@ -44874,54 +44672,54 @@ ymg
 sLi
 sLi
 sLi
-ymg
-ymg
-dPV
-dPV
+kqj
+kqj
+ada
+ada
 tbN
 riD
-aXS
-aXS
-aXS
+acL
+acL
+acL
 abv
 tbN
-dPV
-dPV
-lnn
-abV
-fRr
+ada
+ada
+xDp
+qYz
+pOn
 abZ
 acd
 acc
 acd
 abY
-qmy
-ach
+gog
+kzw
 geF
-abV
-dPV
-dPV
-dPV
-ymg
-uSj
-sLi
-ymg
+yaE
+ada
+ada
+ada
+kqj
+kSI
+tdL
+kqj
 tuX
 tsy
-mhc
-mhc
-mhc
+abX
+abX
+abX
 jHg
 tuX
-ylN
-ylN
-fRr
-fRr
-fRr
-spZ
-biI
-biI
-bxn
+rej
+rej
+pOn
+pOn
+pOn
+bJz
+jSD
+jSD
+vUL
 biI
 fRr
 fRr
@@ -44943,60 +44741,60 @@ vTH
 jMT
 jMT
 jMT
-cQd
+ccX
 mye
-kzW
-kzW
-kzW
-pSx
-dPV
-dPV
-dPV
-lnn
-lnn
-fRr
-fRr
-dPV
-fRr
-fRr
-fRr
-fRr
-dPV
-dPV
-ppp
-ylN
-ylN
-dPV
-dPV
-dPV
-dPV
-lnn
-lnn
-lnn
-dPV
-dPV
-dPV
-lnn
-mVe
-fsP
-fsP
-mVe
-uXC
-lnn
-lnn
-dPu
-lnn
-cQd
+hHC
+hHC
+hHC
+owU
+ada
+ada
+ada
+xDp
+xDp
+pOn
+pOn
+ada
+pOn
+pOn
+pOn
+pOn
+ada
+ada
+acF
+rej
+rej
+ada
+ada
+ada
+ada
+xDp
+xDp
+xDp
+ada
+ada
+ada
+xDp
+hbl
+puh
+puh
+hbl
+pQw
+xDp
+xDp
+lWc
+xDp
+ccX
 tID
 fzp
 sBq
 bOl
 fzp
 ydd
-fsP
-fsP
-lnn
-ooF
+puh
+puh
+xDp
+lsY
 lnn
 lnn
 lnn
@@ -45031,10 +44829,10 @@ ymg
 uSj
 sLi
 sLi
-ymg
-ymg
-dPV
-dPV
+kqj
+kqj
+ada
+ada
 abF
 kmJ
 kmJ
@@ -45042,43 +44840,43 @@ kmJ
 kmJ
 kmJ
 mlT
-dPV
-dPV
-fRr
-fRr
-fRr
+ada
+ada
+pOn
+pOn
+pOn
 abZ
 ace
-rDz
+sPC
 ace
 abY
 xgC
-ach
+kzw
 dIs
-abV
-dPV
-loN
-dPV
-ymg
-ymg
-sLi
-ymg
+yaE
+ada
+rvZ
+ada
+kqj
+kqj
+tdL
+kqj
 tuX
 ibf
-mhc
-mhc
+abX
+abX
 bcv
 ydT
-bxn
-ylN
-ylN
-fRr
-fRr
-fRr
-biI
-biI
-fsP
-bxn
+lRw
+rej
+rej
+pOn
+pOn
+pOn
+jSD
+jSD
+puh
+vUL
 biI
 biI
 biI
@@ -45100,60 +44898,60 @@ vTH
 vTH
 jMT
 jMT
-cQd
+ccX
 ggR
-kzW
-kzW
-kzW
-cQd
-dPV
-dPV
-lnn
-lnn
-lnn
-fRr
-fRr
-lnn
-dPV
-ilZ
-fRr
-fRr
-dPV
-lnn
-lnn
-ylN
-ylN
-dPV
-lnn
-lnn
-lnn
-cdc
-lnn
-lnn
-omo
-omo
-dPV
-mVe
-mVe
-fsP
-fsP
-mVe
-lnn
-lnn
-lnn
-lnn
-lnn
-cQd
+hHC
+hHC
+hHC
+ccX
+ada
+ada
+xDp
+xDp
+xDp
+pOn
+pOn
+xDp
+ada
+cuY
+pOn
+pOn
+ada
+xDp
+xDp
+rej
+rej
+ada
+xDp
+xDp
+xDp
+jHG
+xDp
+xDp
+uMb
+uMb
+ada
+hbl
+hbl
+puh
+puh
+hbl
+xDp
+xDp
+xDp
+xDp
+xDp
+ccX
 tID
 aac
 fzp
 aac
 fzp
-cQd
-fsP
-fsP
-mVe
-lnn
+ccX
+puh
+puh
+hbl
+xDp
 lnn
 lnn
 lnn
@@ -45188,54 +44986,54 @@ ymg
 uSj
 sLi
 sLi
-ymg
-ymg
-fRr
-dPV
+kqj
+kqj
+pOn
+ada
 abG
-fsP
+puh
 abH
-fsP
-fsP
+puh
+puh
 qSD
 hSZ
-dPV
-dPV
-fRr
-fRr
-fRr
+ada
+ada
+pOn
+pOn
+pOn
 abZ
 acf
-rDz
-rDz
+sPC
+sPC
 abY
 kBJ
-bRO
-bRO
+acN
+acN
 vxu
-dPV
-dPV
-dPV
-dPV
-ymg
-sLi
-ymg
+ada
+ada
+ada
+ada
+kqj
+tdL
+kqj
 tuX
 nqL
-mhc
-mhc
+abX
+abX
 uHt
-dwh
+hTt
 uHt
-ylN
-ylN
-fRr
-fRr
-biI
-biI
-fsP
-fsP
-bxn
+rej
+rej
+pOn
+pOn
+jSD
+jSD
+puh
+puh
+vUL
 biI
 biI
 biI
@@ -45257,72 +45055,72 @@ vTH
 vTH
 jMT
 jMT
-cQd
+ccX
 tfo
-kzW
-kzW
-kzW
-cQd
-dPV
-dPV
-lnn
-lnn
-lnn
-fRr
-fRr
-fRr
-fRr
-fRr
-fRr
-fRr
-fRr
-lnn
-fRr
-ylN
-ylN
-omo
-omo
-lnn
-lnn
-lnn
-lnn
-lnn
-bOa
-omo
-dPV
-mVe
-fsP
-fsP
-mVe
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-cQd
+hHC
+hHC
+hHC
+ccX
+ada
+ada
+xDp
+xDp
+xDp
+pOn
+pOn
+pOn
+pOn
+pOn
+pOn
+pOn
+pOn
+xDp
+pOn
+rej
+rej
+uMb
+uMb
+xDp
+xDp
+xDp
+xDp
+xDp
+cHF
+uMb
+ada
+hbl
+puh
+puh
+hbl
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+ccX
 vJd
 fzp
 cJt
 fzp
 pzu
-cQd
-fsP
-fsP
-fsP
-mVe
-lnn
-lnn
-fRr
-fRr
-lnn
-dPV
-fRr
-fRr
-fRr
-lnn
-dPV
-dPV
+ccX
+puh
+puh
+puh
+hbl
+xDp
+xDp
+pOn
+pOn
+xDp
+ada
+pOn
+pOn
+pOn
+xDp
+ada
+ada
 lnn
 fRr
 fRr
@@ -45345,65 +45143,65 @@ ymg
 uSj
 sLi
 sLi
-ymg
-fRr
-ilZ
-ilZ
+kqj
+pOn
+cuY
+cuY
 abG
-fsP
-fsP
-fsP
+puh
+puh
+puh
 abI
 nBF
 hSZ
-dPV
-fRr
-fRr
-abV
-fRr
-abV
-abV
+ada
+pOn
+pOn
+qYz
+pOn
+yaE
+yaE
 aci
-abV
-abV
-abV
+yaE
+yaE
+yaE
 aci
-abV
-abV
-dPV
-dPV
-dPV
-loN
-ymg
-sLi
-ymg
+yaE
+yaE
+ada
+ada
+ada
+rvZ
+kqj
+tdL
+kqj
 tuX
 gYv
-mhc
-cUB
+abX
+nws
 wio
 mhc
 eVl
-ylN
-ylN
-xeY
-fsP
-biI
-biI
-biI
-biI
-mPR
-ilw
-bxn
-bxn
-mPR
-bxn
-ilw
-bxn
-mPR
-lWc
-lWc
-mPR
+rej
+rej
+edS
+puh
+jSD
+jSD
+jSD
+jSD
+san
+bzF
+vUL
+vUL
+san
+vUL
+bzF
+vUL
+san
+ddJ
+ddJ
+san
 xOC
 xOC
 "}
@@ -45414,73 +45212,73 @@ vTH
 vTH
 vTH
 vTH
-cQd
+ccX
 iVc
-kzW
-kzW
-kzW
-cQd
+hHC
+hHC
+hHC
+ccX
 dPz
 dPz
-dPV
-dPV
-dPV
-lnn
-fRr
-fRr
-fRr
-fRr
-fRr
-fRr
-fRr
-fRr
-ilZ
-ylN
-ylN
-dPV
-omo
-dPV
-dPV
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-mVe
-fsP
-fsP
-mVe
-lnn
-lnn
-dPu
-lnn
-lnn
-lnn
-cQd
+ada
+ada
+ada
+xDp
+pOn
+pOn
+pOn
+pOn
+pOn
+pOn
+pOn
+pOn
+cuY
+rej
+rej
+ada
+uMb
+ada
+ada
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+hbl
+puh
+puh
+hbl
+xDp
+xDp
+lWc
+xDp
+xDp
+xDp
+ccX
 dYH
 fzp
 qWh
 fzp
 sVf
-cQd
-mVe
-fsP
-fsP
-mVe
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-dPV
-lnn
-lnn
-dPV
-dPV
-dPV
-lnn
+ccX
+hbl
+puh
+puh
+hbl
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+ada
+xDp
+xDp
+ada
+ada
+ada
+xDp
 lnn
 fRr
 lnn
@@ -45502,64 +45300,64 @@ fRr
 ymg
 sLi
 sLi
-ymg
-ilZ
-fRr
-fRr
+kqj
+cuY
+pOn
+pOn
 abG
-fsP
-fsP
-fsP
+puh
+puh
+puh
 sEp
-fsP
+puh
 hSZ
-dPV
-fRr
-fRr
+ada
+pOn
+pOn
 abU
-fRr
-abV
+pOn
+yaE
 acg
-rDz
-abV
-acn
+sPC
+yaE
+sXV
 act
-rDz
+sPC
 acv
-abV
-dPV
-dPV
-dPV
-dPV
-ymg
-sLi
-ymg
+yaE
+ada
+ada
+ada
+ada
+kqj
+tdL
+kqj
 uHt
-dwh
-dwh
-fJU
+hTt
+hTt
+jwv
 uHt
 mhc
 eUj
-ylN
-ylN
-ylN
-fsP
-fsP
-biI
-biI
-ylN
+rej
+rej
+rej
+puh
+puh
+jSD
+jSD
+rej
 tgU
-ylN
-ylN
-ylN
-kUT
-kUT
-kUT
-kUT
+rej
+rej
+rej
+hGT
+hGT
+hGT
+hGT
 cui
-kUT
-kUT
+hGT
+hGT
 vpe
 xOC
 xOC
@@ -45571,74 +45369,74 @@ vTH
 vTH
 vTH
 vTH
-cQd
-cQd
-cQd
-cQd
-cQd
-cQd
+ccX
+ccX
+ccX
+ccX
+ccX
+ccX
 dPz
 dPz
 dPz
-dPV
-dPV
+ada
+ada
 log
-fRr
-fRr
-fRr
-fRr
-fRr
-fRr
-fRr
+pOn
+pOn
+pOn
+pOn
+pOn
+pOn
+pOn
 kzk
-ilZ
-ylN
-ylN
-ylN
-dPV
-dPV
-lnn
-lnn
-lnn
-lnn
-dPV
-qal
-mVe
-mVe
-fsP
-fsP
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-cQd
+cuY
+rej
+rej
+rej
+ada
+ada
+xDp
+xDp
+xDp
+xDp
+ada
+dDS
+hbl
+hbl
+puh
+puh
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+ccX
 tbK
 fzp
 fzp
 fzp
 suB
-cQd
-fRr
-fsP
-fsP
-xeY
-lnn
-lnn
-lnn
-lnn
-lnn
-obx
-obx
+ccX
+pOn
+puh
+puh
+edS
+xDp
+xDp
+xDp
+xDp
+xDp
+uHt
+uHt
 dMQ
-obx
-obx
-lnn
-lnn
-vIK
-lnn
+uHt
+uHt
+xDp
+xDp
+ach
+xDp
 lnn
 lnn
 fwr
@@ -45659,65 +45457,65 @@ fRr
 ymg
 sLi
 sLi
-ymg
-fRr
-fRr
-cQd
-cQd
-ylN
-ylN
+kqj
+pOn
+pOn
+lyP
+lyP
+rej
+rej
 sEp
-ylN
-ylN
-cQd
-dPV
-dPV
-fRr
-fRr
-fRr
+rej
+rej
+lyP
+ada
+ada
+pOn
+pOn
+pOn
 aca
-rDz
+sPC
 ack
-abV
+yaE
 acp
-rDz
+sPC
 vGx
 wFI
-abV
+yaE
 acS
-dPV
-dPV
-dPV
-ymg
-sLi
-ymg
-ymg
+ada
+ada
+ada
+kqj
+tdL
+kqj
+kqj
 eVf
-ymg
-ymg
+kqj
+kqj
 fUJ
 qRd
 jwA
-ylN
-ylN
-ylN
-fRr
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
+rej
+rej
+rej
+pOn
+rej
+rej
+rej
+rej
+rej
+rej
+rej
 aay
-bxn
-kUT
-kUT
-kUT
-kUT
-kUT
-kUT
-bxn
+vUL
+hGT
+hGT
+hGT
+hGT
+hGT
+hGT
+vUL
 xOC
 xOC
 "}
@@ -45738,72 +45536,72 @@ dPz
 dPz
 dPz
 dPz
-dPV
-dPV
-ilZ
-ilZ
-fRr
-lnn
-lnn
-fRr
-fRr
-ilZ
-ilZ
-ylN
-ylN
-ylN
-dPV
-dPV
-dPV
-dPV
-dPV
-dPV
-lnn
-dPV
-mVe
-fsP
-fsP
-mVe
-lnn
-veh
-lnn
-lnn
-lnn
-uXC
-lnn
-cQd
+ada
+ada
+cuY
+cuY
+pOn
+xDp
+xDp
+pOn
+pOn
+cuY
+cuY
+rej
+rej
+rej
+ada
+ada
+ada
+ada
+ada
+ada
+xDp
+ada
+hbl
+puh
+puh
+hbl
+xDp
+cZg
+xDp
+xDp
+xDp
+pQw
+xDp
+ccX
 flD
 aad
 fzp
 aad
 phd
-cQd
-fRr
-mVe
-fsP
-fsP
-lnn
-lnn
-lnn
-ooF
+ccX
+pOn
+hbl
+puh
+puh
+xDp
+xDp
+xDp
+lsY
 lOh
-obx
-tSL
+uHt
+kzW
 jPJ
 diq
-obx
 uHt
-lnn
-lnn
-lnn
-lnn
-lnn
-fRr
-fRr
-fRr
-fRr
-lnn
-lnn
+uHt
+xDp
+xDp
+xDp
+xDp
+xDp
+pOn
+pOn
+pOn
+pOn
+xDp
+xDp
 lnn
 lnn
 lnn
@@ -45815,66 +45613,66 @@ fRr
 fRr
 ymg
 sLi
-sLi
-ymg
-lnn
-lnn
-cQd
+tdL
+kqj
+xDp
+xDp
+lyP
 vJT
 mhz
-cQd
+lyP
 dJj
-cQd
+lyP
 abJ
 kmJ
 mhz
 mhz
 iJp
-ylN
-fRr
+rej
+pOn
 acb
-ach
-rDz
+kzw
+sPC
 acm
-rDz
-rDz
-rDz
-ach
+sPC
+sPC
+sPC
+kzw
 sOf
-ylN
-ylN
-dPV
-dPV
-ymg
-uSj
-sLi
-ymg
+rej
+rej
+ada
+ada
+kqj
+kSI
+tdL
+kqj
 eVf
-ymg
-ymg
+kqj
+kqj
 jTm
 amn
-fRr
-ylN
-ylN
-ylN
-fRr
-fRr
-biI
-biI
-biI
-biI
-biI
-bxn
-bxn
-bxn
-bxn
-bxn
-bxn
-bxn
-bxn
-bxn
-bxn
+pOn
+rej
+rej
+rej
+pOn
+pOn
+jSD
+jSD
+jSD
+jSD
+jSD
+vUL
+vUL
+vUL
+vUL
+vUL
+vUL
+vUL
+vUL
+vUL
+vUL
 xOC
 xOC
 "}
@@ -45895,74 +45693,74 @@ dPz
 dPz
 dPz
 dPz
-dPV
+ada
 log
-lnn
-ilZ
-ilZ
-lnn
-lnn
-lnn
-fRr
-fRr
-ylN
-ylN
-ylN
-ylN
-pHC
-lnn
-dPV
-dPV
-dPV
-dPV
-bOa
-lnn
-mVe
-fsP
-fsP
-mVe
-lnn
-lnn
-veh
-lnn
-lnn
-lnn
-lnn
-cQd
-cQd
+xDp
+cuY
+cuY
+xDp
+xDp
+xDp
+pOn
+pOn
+rej
+rej
+rej
+rej
+wxW
+xDp
+ada
+ada
+ada
+ada
+cHF
+xDp
+hbl
+puh
+puh
+hbl
+xDp
+xDp
+cZg
+xDp
+xDp
+xDp
+xDp
+ccX
+ccX
 fzp
 dVK
 dWZ
-cQd
-cQd
-fRr
-ilZ
-fsP
-fsP
-mVe
-lnn
-lnn
-lnn
+ccX
+ccX
+pOn
+cuY
+puh
+puh
+hbl
+xDp
+xDp
+xDp
 uHt
 xbr
-bRO
-bRO
-bRO
+acN
+acN
+acN
 gzO
 uHt
 bWL
-lnn
-lnn
-ylN
-ylN
-ylN
-ylN
-lnn
-fwr
-fRr
-fRr
-fRr
-lnn
+xDp
+xDp
+rej
+rej
+rej
+rej
+xDp
+lAV
+pOn
+pOn
+pOn
+xDp
 lnn
 lnn
 lnn
@@ -45972,62 +45770,62 @@ lnn
 ilZ
 fRr
 sLi
-sLi
-ymg
-lnn
-lnn
-cQd
+tdL
+kqj
+xDp
+xDp
+lyP
 kNz
-ylN
-ylN
-fsP
+rej
+rej
+puh
 sLt
-mPR
+san
 chq
 bzL
 hre
 soi
-ylN
-fRr
+rej
+pOn
 aca
-rDz
+sPC
 ack
-abV
+yaE
 acq
-rDz
-rDz
+sPC
+sPC
 ack
-abV
+yaE
 acS
-ylN
-dPV
-dPV
-ymg
-ymg
-sLi
-ymg
+rej
+ada
+ada
+kqj
+kqj
+tdL
+kqj
 xiF
-ymg
-ymg
-ymg
+kqj
+kqj
+kqj
 kwg
 siw
-ylN
-ylN
-ylN
-fRr
-ilZ
-biI
-biI
-biI
-biI
-biI
-biI
-biI
+rej
+rej
+rej
+pOn
+cuY
+jSD
+jSD
+jSD
+jSD
+jSD
+jSD
+jSD
 uHt
-inM
-inM
-inM
+oHl
+oHl
+oHl
 uHt
 xOC
 xOC
@@ -46052,76 +45850,76 @@ dPz
 dPz
 dPz
 dPz
-dPV
+ada
 log
-lnn
-lnn
-fRr
-fRr
-lnn
-lnn
-lnn
-fRr
-ylN
-ylN
-ylN
-dPV
-dPV
-lnn
-dPV
-dPV
-dPV
-omo
-omo
-dPV
-fsP
-fsP
-fsP
-lnn
-lnn
-lnn
-lnn
-dPV
-lnn
-lnn
-lnn
-lnn
-cQd
-cQd
+xDp
+xDp
+pOn
+pOn
+xDp
+xDp
+xDp
+pOn
+rej
+rej
+rej
+ada
+ada
+xDp
+ada
+ada
+ada
+uMb
+uMb
+ada
+puh
+puh
+puh
+xDp
+xDp
+xDp
+xDp
+ada
+xDp
+xDp
+xDp
+xDp
+ccX
+ccX
 wSF
-cQd
-cQd
-fRr
-fRr
-fsP
-fsP
-mVe
-lnn
-veh
-lnn
-lnn
-edS
+ccX
+ccX
+pOn
+pOn
+puh
+puh
+hbl
+xDp
+cZg
+xDp
+xDp
+abj
 nyn
-bRO
+acN
 fUV
-bRO
-bRO
+acN
+acN
 iSJ
-ylN
-lnn
-ylN
-ylN
+rej
+xDp
+rej
+rej
 xqr
 xqr
-ylN
-lnn
-fRr
-fwr
-fRr
-fRr
-lnn
-lnn
-lnn
+rej
+xDp
+pOn
+lAV
+pOn
+pOn
+xDp
+xDp
+xDp
 lnn
 lnn
 lnn
@@ -46129,13 +45927,13 @@ lnn
 fRr
 fRr
 sLi
-sLi
-cQd
-cQd
-lnn
-dPV
-cQd
-ylN
+tdL
+lyP
+lyP
+xDp
+ada
+lyP
+rej
 vDP
 rPV
 rPV
@@ -46144,48 +45942,48 @@ rPV
 rPV
 rPV
 bDW
-ylN
-ylN
-abV
-rDz
+rej
+rej
+yaE
+sPC
 acl
-abV
+yaE
 acr
-rDz
+sPC
 acw
-rDz
-abV
-ylN
-ylN
-dPV
-dPV
-dPV
-ymg
-sLi
-ymg
+sPC
+yaE
+rej
+rej
+ada
+ada
+ada
+kqj
+tdL
+kqj
 xiF
-hiR
-ymg
-ymg
+wrd
+kqj
+kqj
 kwg
 uUR
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-biI
-biI
-biI
-biI
-kqj
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+jSD
+jSD
+jSD
+jSD
+rUz
 wNB
 rrK
-inM
-inM
+oHl
+oHl
 xOC
 xOC
 xOC
@@ -46208,86 +46006,86 @@ dPz
 dPz
 dPz
 dPz
-dPV
-dPV
+ada
+ada
 log
-lnn
-lnn
-fRr
-fRr
-lnn
-cdc
-lnn
-dPV
-ylN
-ylN
-ylN
-dPV
-dPV
-dPV
-dPV
-lnn
-dPV
-dPV
-lnn
-mVe
-fsP
-fsP
-mVe
-lnn
-lnn
-lnn
-lnn
-dPu
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-fRr
-mVe
-fsP
-fsP
-dPV
-dPV
-lnn
-lnn
-lnn
+xDp
+xDp
+pOn
+pOn
+xDp
+jHG
+xDp
+ada
+rej
+rej
+rej
+ada
+ada
+ada
+ada
+xDp
+ada
+ada
+xDp
+hbl
+puh
+puh
+hbl
+xDp
+xDp
+xDp
+xDp
+lWc
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+pOn
+hbl
+puh
+puh
+ada
+ada
+xDp
+xDp
+xDp
 uHt
 xbr
-bRO
-bRO
-bRO
+acN
+acN
+acN
 vud
 uHt
 acS
-lnn
-ylN
+xDp
+rej
 xqr
 xqr
 xqr
-aat
+ccX
 lRw
 lRw
 lRw
-aat
-fRr
-fRr
-jBO
-fRr
-lnn
+ccX
+pOn
+pOn
+acB
+pOn
+xDp
 lnn
 lnn
 lnn
 lnn
 ilZ
-sLi
-sLi
-cQd
+tdL
+tdL
+lyP
 txr
 mhz
 mhz
@@ -46301,48 +46099,48 @@ kAl
 kAl
 kAl
 ssO
-ylN
-ylN
-abV
-rDz
-abV
-abV
-abV
+rej
+rej
+yaE
+sPC
+yaE
+yaE
+yaE
 acu
-abV
+yaE
 acu
-abV
-ylN
-ylN
-dPV
-loN
-dPV
-ymg
-sLi
-ymg
+yaE
+rej
+rej
+ada
+rvZ
+ada
+kqj
+tdL
+kqj
 xiF
 fUJ
-ymg
-fRr
+kqj
+pOn
 kwg
 siw
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-biI
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+jSD
 tuX
 wNB
 wNB
 xyp
-fJU
+jwv
 xOC
 xOC
 xOC
@@ -46365,141 +46163,141 @@ dPz
 dPz
 dPz
 dPz
-dPV
-xfD
-dPV
-lnn
-lnn
-lnn
-fRr
-fRr
-lnn
-lnn
-dPV
-ylN
-ylN
-ylN
-ylN
-dPV
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-mVe
-fsP
-fsP
-mVe
-lnn
-lnn
-lnn
-lnn
-dPV
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-cdc
-lnn
-fRr
-mVe
-fsP
-aat
+ada
+wNi
+ada
+xDp
+xDp
+xDp
+pOn
+pOn
+xDp
+xDp
+ada
+rej
+rej
+rej
+rej
+ada
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+hbl
+puh
+puh
+hbl
+xDp
+xDp
+xDp
+xDp
+ada
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+jHG
+xDp
+pOn
+hbl
+puh
+lyP
 hbl
 puh
 dSe
-aat
-dPV
+lyP
+ada
 uHt
 uHt
 qlx
-acF
+gbn
 mrM
-obx
 uHt
-ylN
-lnn
-ylN
+uHt
+rej
+xDp
+rej
 xqr
 xxv
 xqr
 lRw
 acW
 ats
-mRr
+fzp
 lRw
-fwr
-fRr
-fRr
-fRr
-fRr
-fRr
-lnn
-lnn
-lnn
-lnn
-sLi
-sLi
+lAV
+pOn
+pOn
+pOn
+pOn
+pOn
+xDp
+xDp
+xDp
+xDp
+tdL
+tdL
 kFM
 aag
 aag
 aag
-ylN
+rej
 iSL
 ptM
-mVe
-mVe
-mVe
-mVe
-mVe
-mVe
+hbl
+hbl
+hbl
+hbl
+hbl
+hbl
 ebf
-ylN
-ylN
-abV
+rej
+rej
+yaE
 aci
-abV
-abV
-lnn
-lnn
-lnn
-lnn
-lnn
-ylN
-ylN
-dPV
-dPV
-dPV
-ymg
-sLi
-ymg
+yaE
+yaE
+xDp
+xDp
+xDp
+xDp
+xDp
+rej
+rej
+ada
+ada
+ada
+kqj
+tdL
+kqj
 xiF
-hiR
-fRr
+wrd
+pOn
 pnc
 wcb
-fRr
-ylN
-ylN
-ylN
-fRr
-biI
-biI
-biI
-ylN
-ylN
-ylN
-ylN
-ylN
+pOn
+rej
+rej
+rej
+pOn
+jSD
+jSD
+jSD
+rej
+rej
+rej
+rej
+rej
 gaK
 wNB
 wNB
 odw
-fJU
+jwv
 xOC
 xOC
 xOC
@@ -46521,91 +46319,91 @@ dPz
 dPz
 dPz
 dPz
-mVe
-mVe
-dPV
-dPV
-lnn
-lnn
-lnn
-ilZ
-fRr
-lnn
-lnn
-dPV
-ylN
-ylN
-ylN
-ylN
-dPV
-lnn
-dPV
-pHC
-dPV
-dPV
-mVe
-mVe
-fsP
-fsP
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-veh
-lnn
-lnn
-lnn
-fRr
-fRr
-mVe
-fsP
+hbl
+hbl
+ada
+ada
+xDp
+xDp
+xDp
+cuY
+pOn
+xDp
+xDp
+ada
+rej
+rej
+rej
+rej
+ada
+xDp
+ada
+wxW
+ada
+ada
+hbl
+hbl
+puh
+puh
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+cZg
+xDp
+xDp
+xDp
+pOn
+pOn
+hbl
+puh
 fZv
 puh
 puh
 puh
-cuY
-lnn
-lnn
+ckv
+xDp
+xDp
 uHt
 uHt
 wDU
-obx
-obx
-ylN
-ylN
-lnn
-ylN
+uHt
+uHt
+rej
+rej
+xDp
+rej
 xqr
 xqr
 xqr
 lRw
 acX
-mRr
-giU
+fzp
+ade
 lRw
 lRw
 lRw
-aat
-lnn
-fRr
-fwr
-lnn
-lnn
-lnn
-lnn
-sLi
-sLi
+ccX
+xDp
+pOn
+lAV
+xDp
+xDp
+xDp
+xDp
+tdL
+tdL
 mek
 aag
 aag
-ylN
-ylN
+rej
+rej
 iSL
 fcC
 kAl
@@ -46615,48 +46413,48 @@ kAl
 kAl
 kAl
 fZy
-ylN
-ylN
-abV
-rDz
+rej
+rej
+yaE
+sPC
 rCZ
-abV
-lnn
+yaE
+xDp
 wmK
 sKj
 sKj
 sKj
 iGv
 hKJ
-dPV
-dPV
-dPV
-ymg
-sLi
-ymg
+ada
+ada
+ada
+kqj
+tdL
+kqj
 chd
-fRr
-fRr
-fRr
-fRr
-ylN
-ylN
-ylN
-fRr
-fRr
-biI
-biI
-biI
-ylN
-ylN
-ylN
-ylN
-biI
+pOn
+pOn
+pOn
+pOn
+rej
+rej
+rej
+pOn
+pOn
+jSD
+jSD
+jSD
+rej
+rej
+rej
+rej
+jSD
 tuX
 kcN
 wNB
 urN
-fJU
+jwv
 xOC
 xOC
 xOC
@@ -46676,108 +46474,108 @@ dPV
 lnn
 lnn
 dPz
-bxn
-bxn
-mVe
-mVe
-mVe
-bxn
-lnn
-lnn
-dPV
-dPV
-dPV
-fRr
-dPV
-dPV
-dPV
-ylN
-ylN
-ylN
-bOa
-lnn
-lnn
-dPV
-dPV
-dPV
-mVe
-mVe
-fsP
-fsP
-lnn
-dXm
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-veh
-lnn
-lnn
-lnn
-fRr
-mVe
-fsP
-fsP
+vUL
+vUL
+hbl
+hbl
+hbl
+vUL
+xDp
+xDp
+ada
+ada
+ada
+pOn
+ada
+ada
+ada
+rej
+rej
+rej
+cHF
+xDp
+xDp
+ada
+ada
+ada
+hbl
+hbl
+puh
+puh
+xDp
+pSx
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+cZg
+xDp
+xDp
+xDp
+pOn
+hbl
+puh
+puh
 cIV
 puh
 puh
 puh
-cuY
-fsP
-lnn
-lnn
-lnn
+ckv
+puh
+xDp
+xDp
+xDp
 ada
 ada
 ada
-ylN
-aat
+rej
+ccX
 lRw
 lRw
 lRw
 lRw
 lRw
-aat
-mRr
-mRr
+ccX
+fzp
+fzp
 lRw
 acZ
 ats
 ygb
 lRw
-lnn
-fRr
+xDp
+pOn
 lgQ
-fRr
-lnn
-lnn
-lnn
-sLi
-sLi
+pOn
+xDp
+xDp
+xDp
+tdL
+tdL
 kJH
 jIC
-ylN
-ylN
-ylN
-ylN
+rej
+rej
+rej
+rej
 efp
-mVe
-mVe
-mVe
-mVe
-mVe
-mVe
+hbl
+hbl
+hbl
+hbl
+hbl
+hbl
 pJn
-ylN
-ylN
-abV
-abV
-abV
-abV
+rej
+rej
+yaE
+yaE
+yaE
+yaE
 eNm
 bqr
 cnA
@@ -46785,35 +46583,35 @@ vDq
 kWL
 dfy
 bIu
-ylN
-dPV
-fsP
-ymg
-sLi
-ymg
-ymg
-eVf
-fRr
-pjk
-fRr
-ylN
-ylN
-ylN
-ilZ
-fRr
-biI
-biI
-biI
-ylN
-ylN
-biI
-biI
-ltN
+rej
+ada
+puh
 kqj
+tdL
+kqj
+kqj
+eVf
+pOn
+toZ
+pOn
+rej
+rej
+rej
+cuY
+pOn
+jSD
+jSD
+jSD
+rej
+rej
+jSD
+jSD
+ltN
+rUz
 wNB
 wNB
 nAk
-inM
+oHl
 xOC
 xOC
 xOC
@@ -46833,94 +46631,94 @@ lnn
 lnn
 dPV
 mVe
-mPR
-mVe
-mVe
-fsP
-fsP
-bxn
+san
+hbl
+hbl
+puh
+puh
+vUL
 dHH
-dPV
-pHC
-dPV
-dPV
-dPV
-dPV
-mVe
-fsP
-ylN
-ylN
-dPV
-lnn
-dPV
-dPV
-dPV
-dPV
+ada
+wxW
+ada
+ada
+ada
+ada
+hbl
+puh
+rej
+rej
+ada
+xDp
+ada
+ada
+ada
+ada
 xnl
-mVe
-fsP
-fsP
-fsP
-jPw
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-fRr
-mVe
-fsP
-fsP
+hbl
+puh
+puh
+puh
+ckv
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+pOn
+hbl
+puh
+puh
 gwT
 puh
 puh
 puh
-cuY
-fsP
-lnn
-lnn
-cdc
-lnn
+ckv
+puh
+xDp
+xDp
+jHG
+xDp
 ada
 ada
-ylN
+rej
 lRw
 adl
 oWz
 oWz
-mRr
-aat
-mRr
-mRr
-mRr
-aat
+fzp
+ccX
+fzp
+fzp
+fzp
+ccX
 adb
-mRr
-vUb
+fzp
+dYH
 adc
-lnn
-lnn
-fRr
-fRr
-lnn
-lnn
-lnn
-sLi
-sLi
+xDp
+xDp
+pOn
+pOn
+xDp
+xDp
+xDp
+tdL
+tdL
 kJH
-ylN
-cQd
+rej
+lyP
 aJW
-ylN
-ylN
+rej
+rej
 ptM
 kAl
 kAl
@@ -46929,12 +46727,12 @@ kAl
 kAl
 kAl
 bAL
-ylN
+rej
 abg
 cry
-ylN
+rej
 cry
-ylN
+rej
 mdn
 bqr
 kNe
@@ -46942,34 +46740,34 @@ xwA
 kWL
 uqO
 bIu
-ylN
-fsP
-fsP
-ymg
-uSj
-sLi
-ymg
+rej
+puh
+puh
+kqj
+kSI
+tdL
+kqj
 eVf
-fRr
-fRr
-ylN
-ylN
-ylN
-ylN
-fRr
-fRr
-fRr
+pOn
+pOn
+rej
+rej
+rej
+rej
+pOn
+pOn
+pOn
 uHt
-mPR
+oLW
 gjv
-mPR
+oLW
 uHt
-biI
-mPR
-mPR
+jSD
+oLW
+oLW
 uHD
 iGX
-inM
+oHl
 uHt
 xOC
 xOC
@@ -46992,92 +46790,92 @@ ylN
 ylN
 kPo
 xnl
-fsP
-fsP
-nPK
-fsP
-dPV
-dPV
-dPV
-mVe
-mVe
-fsP
-fsP
-fsP
-ylN
-ylN
-ylN
-dPV
-lnn
-dPV
-mVe
-mVe
-mVe
-fsP
-fsP
-fsP
-fsP
-fsP
-jPw
-ylN
-lnn
-lnn
+puh
+puh
+moC
+puh
+ada
+ada
+ada
+hbl
+hbl
+puh
+puh
+puh
+rej
+rej
+rej
+ada
+xDp
+ada
+hbl
+hbl
+hbl
+puh
+puh
+puh
+puh
+puh
+ckv
+rej
+xDp
+xDp
 iSL
 anh
 iSL
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-rbo
-fRr
-fsP
-fsP
-aat
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+oIO
+pOn
+puh
+puh
+lyP
 puh
 puh
 puh
-aat
-fsP
-lnn
-lnn
-lnn
-lnn
-lnn
-mVe
-ylN
+lyP
+puh
+xDp
+xDp
+xDp
+xDp
+xDp
+hbl
+rej
 lRw
 acT
-mRr
+fzp
 acU
-mRr
+fzp
 acV
-mRr
-mRr
-mRr
+fzp
+fzp
+fzp
 acV
-mRr
-mRr
+fzp
+fzp
 mDu
 lRw
-lnn
-fRr
-fwr
-fRr
-lnn
+xDp
+pOn
+lAV
+pOn
+xDp
 fAD
 enU
-sLi
-sLi
+tdL
+tdL
 kJH
 idt
-cQd
+lyP
 uJj
-ylN
-cQd
+rej
+lyP
 qBT
 cxb
 cxb
@@ -47086,48 +46884,48 @@ cxb
 cxb
 cxb
 bCv
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
+rej
+rej
+rej
+rej
+rej
+rej
+rej
 bqr
 wSX
 kWL
 iSL
 pIG
 pub
-fsP
-fsP
-fsP
-ymg
-ymg
-sLi
-ymg
+puh
+puh
+puh
+kqj
+kqj
+tdL
+kqj
 inK
-fRr
-fRr
+pOn
+pOn
 abd
-ylN
-ylN
-fsP
-fRr
-fRr
-fRr
-inM
+rej
+rej
+puh
+pOn
+pOn
+pOn
+oHl
 kcN
 wNB
 wNB
-inM
-biI
-mPR
+oHl
+jSD
+oLW
 shp
-iSL
-iSL
-iSL
-inM
+sPC
+sPC
+sPC
+oHl
 xOC
 xOC
 xOC
@@ -47148,35 +46946,35 @@ ylN
 ylN
 ylN
 smK
-ylN
-ylN
-ylN
-ylN
-ylN
-lnn
-mVe
-fsP
-fsP
-fsP
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-dPV
-mVe
-mVe
-fsP
-fsP
-fsP
-ylN
-ylN
-ylN
-fsP
-ylN
-ylN
+rej
+rej
+rej
+rej
+rej
+xDp
+hbl
+puh
+puh
+puh
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+ada
+hbl
+hbl
+puh
+puh
+puh
+rej
+rej
+rej
+puh
+rej
+rej
 gSm
 nKp
 kWL
@@ -47186,105 +46984,105 @@ iSL
 iSL
 iSL
 iSL
-dPV
-dPV
-dPV
-dPV
-fRr
+ada
+ada
+ada
+ada
+pOn
 iSL
-fsP
+puh
 iSL
-fsP
-fsP
+puh
+puh
 iSL
-fsP
-ylN
-iSL
-iSL
-dPV
-dPV
-mVe
+puh
+rej
 iSL
 iSL
-aat
+ada
+ada
+hbl
+iSL
+iSL
+ccX
 lRw
 lRw
 lRw
 lRw
 lRw
 lRw
-aat
-sEN
-aat
+ccX
+ydd
+ccX
 lRw
 lRw
 lRw
-aat
+ccX
 qYz
-dPV
-dPV
+ada
+ada
 qKg
 rZz
 lrD
-kzW
+rJC
 fAD
 fAD
 fAD
 fAD
-cQd
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
+lyP
+rej
+rej
+rej
+rej
+rej
+rej
+rej
 abg
-ylN
-ylN
-ylN
-ylN
-ylN
+rej
+rej
+rej
+rej
+rej
 abg
-ylN
-ylN
-ylN
-ylN
+rej
+rej
+rej
+rej
 mdn
 rJM
 rJM
 rJM
 lgj
 hrK
-ylN
-ylN
-fsP
-fsP
-ymg
-sLi
-ymg
-nPK
-fsP
-ylN
+rej
+rej
+puh
+puh
+kqj
+tdL
+kqj
+moC
+puh
+rej
 abd
 abd
-ylN
-fsP
-fRr
-fRr
-fRr
-inM
+rej
+puh
+pOn
+pOn
+pOn
+oHl
 kcN
 wNB
 xyp
-inM
-biI
-inM
+oHl
+jSD
+oHl
 oeZ
-ljo
-iSL
+acr
+sPC
 mAD
-inM
+oHl
 xOC
 xOC
 xOC
@@ -47305,63 +47103,63 @@ ylN
 ylN
 ylN
 kEx
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
 gSm
 nKp
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
+rej
+rej
+rej
+rej
+rej
+rej
 iSL
 iSL
 iSL
 iSL
-ylN
+rej
 iSL
 iSL
 iSL
-ylN
-iSL
-iSL
-iSL
-iSL
-iSL
+rej
 iSL
 iSL
 iSL
 iSL
 iSL
-ylN
+iSL
+iSL
+iSL
+iSL
+iSL
+rej
 iSL
 cvr
 qYz
@@ -47383,51 +47181,51 @@ qYz
 qYz
 qYz
 akp
-kzW
-kzW
+rJC
+rJC
 abf
-kzW
-kzW
-ylN
-ylN
-ylN
-ylN
+rJC
+rJC
+rej
+rej
+rej
+rej
 abg
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
+rej
+rej
+rej
+rej
+rej
+rej
+rej
 fdT
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
+rej
+rej
+rej
+rej
+rej
+rej
 abg
-ylN
-ylN
-ylN
-ylN
+rej
+rej
+rej
+rej
 abg
-ylN
-ylN
-ylN
+rej
+rej
+rej
 wOE
 uRQ
 uRQ
 uRQ
 uRQ
 aRe
-ylN
-ylN
-ylN
-ylN
-fRr
-fRr
+rej
+rej
+rej
+rej
+pOn
+pOn
 uHt
 sYJ
 uHt
@@ -47435,11 +47233,11 @@ rYT
 wNB
 odw
 uHt
-biI
+jSD
 uHt
 ihI
-dwh
-dwh
+hTt
+hTt
 vvZ
 uHt
 xOC
@@ -47462,138 +47260,138 @@ ylN
 ylN
 ylN
 kEx
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
 cPJ
 cPJ
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
+rej
+rej
+rej
+rej
+rej
+rej
 cPJ
 cPJ
 cPJ
-ylN
+rej
 gSm
 nKp
 iSL
-ylN
-ylN
-ylN
+rej
+rej
+rej
 iSL
-ylN
-ylN
-iSL
-iSL
-iSL
-ylN
-ylN
+rej
+rej
 iSL
 iSL
 iSL
-iSL
-ylN
-iSL
-iSL
-iSL
-ylN
-ylN
+rej
+rej
 iSL
 iSL
 iSL
 iSL
-ylN
+rej
+iSL
+iSL
+iSL
+rej
+rej
+iSL
+iSL
+iSL
+iSL
+rej
 cvr
 qYz
 qYz
 qYz
-ylN
+rej
 iSL
-ylN
-iSL
-iSL
-iSL
-ylN
+rej
 iSL
 iSL
-ylN
+iSL
+rej
+iSL
+iSL
+rej
 iSL
 bvV
 qYz
 qYz
 qYz
 rcK
-kzW
-kzW
-kzW
-kzW
-kzW
-ylN
-ylN
+rJC
+rJC
+rJC
+rJC
+rJC
+rej
+rej
 lkx
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
 abg
-ylN
-ylN
-ylN
-ylN
-ylN
+rej
+rej
+rej
+rej
+rej
 abg
-ylN
-ylN
-ylN
-ylN
-ylN
+rej
+rej
+rej
+rej
+rej
 wOE
 qzM
 qzM
 qzM
 qzM
 aRe
-ylN
-ylN
-ylN
-fsP
-fRr
-biI
-mPR
+rej
+rej
+rej
+puh
+pOn
+jSD
+oLW
 wiB
-ljo
+acr
 qla
 wNB
 urN
-inM
-biI
-biI
+oHl
+jSD
+jSD
 xOC
 xOC
 xOC
@@ -47619,61 +47417,61 @@ ylN
 ylN
 ylN
 xzz
-ylN
-ylN
-ylN
-ylN
-ylN
-lnn
-xfD
-mVe
-fsP
-fsP
-fsP
-ylN
-ylN
-ylN
-ylN
+rej
+rej
+rej
+rej
+rej
+xDp
+wNi
+hbl
+puh
+puh
+puh
+rej
+rej
+rej
+rej
 bpV
 xzP
-lnn
-lnn
+xDp
+xDp
 epS
 cPJ
 cPJ
 cPJ
 cPJ
 hTH
-lnn
-lnn
-lnn
+xDp
+xDp
+xDp
 epS
 gSm
 nKp
-ylN
-ylN
+rej
+rej
 iSL
 iSL
-ylN
-ylN
-iSL
-iSL
-iSL
-ylN
-ylN
-ylN
-ylN
-iSL
-iSL
-ylN
+rej
+rej
 iSL
 iSL
 iSL
+rej
+rej
+rej
+rej
+iSL
+iSL
+rej
 iSL
 iSL
 iSL
 iSL
-ylN
+iSL
+iSL
+iSL
+rej
 iSL
 iSL
 xIu
@@ -47684,73 +47482,73 @@ iSL
 iSL
 aiO
 aCU
-ylN
+rej
 iSL
 iSL
-ylN
+rej
 wiu
 iSL
 iSL
 iSL
-ylN
+rej
 iSL
 teY
 teY
 waG
-kzW
+rJC
 dXL
 tVC
 tVC
 tVC
-cQd
+lyP
 kWL
-fsP
-ylN
-ylN
-ylN
+puh
+rej
+rej
+rej
 abg
-ylN
-dPV
-fsP
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-fsP
-dPV
-dPV
-jzM
-dPV
-fsP
-mVe
-ylN
-ylN
-ylN
-fsP
-fsP
-ymg
-sLi
-sLi
-ymg
-fsP
+rej
+ada
+puh
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+puh
+ada
+ada
+aaG
+ada
+puh
+hbl
+rej
+rej
+rej
+puh
+puh
+kqj
+tdL
+tdL
+kqj
+puh
 abc
 abd
-ppp
-biI
-biI
+acF
+jSD
+jSD
 sYJ
 oeZ
-iSL
+sPC
 qla
 wNB
 nAk
 uHt
-biI
-biI
+jSD
+jSD
 xOC
 xOC
 xOC
@@ -47776,36 +47574,36 @@ ylN
 ylN
 mVe
 kPo
-nPK
-mVe
-mVe
+moC
+hbl
+hbl
 xnl
-fsP
-dPV
-dPV
-lnn
-mVe
-fsP
-fsP
-nPK
-ilw
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-vIK
-lnn
-lnn
-lnn
-cQd
+puh
+ada
+ada
+xDp
+hbl
+puh
+puh
+moC
+bzF
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+ach
+xDp
+xDp
+xDp
+lyP
 kWL
 kWL
 bWh
@@ -47826,15 +47624,15 @@ kWL
 kWL
 kWL
 kWL
-ylN
+rej
 kWL
 kWL
 qSS
 kWL
 kWL
 bWh
-jrz
-jrz
+ngE
+ngE
 iSL
 rYw
 haj
@@ -47852,60 +47650,60 @@ ygR
 haj
 haj
 abe
-fsP
-kzW
+puh
+rJC
 dJz
-sLi
-sLi
+tdL
+tdL
 bWh
 kWL
 kWL
 pha
 kWL
-fsP
+puh
 iGv
 iGv
 iGv
 sKj
 mOa
 tbN
-fsP
-fsP
-ylN
-ilw
-rrv
-fsP
+puh
+puh
+rej
+uEJ
+fyG
+qyk
 aaB
 aaD
-ilw
-dPV
-dPV
-dPV
-dPV
-dPV
-dPV
+uEJ
+ada
+ada
+ada
+ada
+ada
+ada
 rrv
 abg
-ylN
-fsP
-fsP
-ymg
-uSj
-sLi
-ymg
-fsP
+rej
+puh
+puh
+kqj
+kSI
+tdL
+kqj
+puh
 abc
-ylN
-ylN
-biI
-biI
+rej
+rej
+jSD
+jSD
 uHt
-inM
-inM
+oHl
+oHl
 uHt
 lYH
 wNB
-inM
+oHl
 hbi
 hbi
 xOC
@@ -47932,65 +47730,65 @@ bKz
 bKz
 bKz
 dPz
-mPR
-mVe
-fsP
-fsP
-fsP
-dPV
-dPV
-xOC
-dPV
-mVe
-fsP
-fsP
-ilw
-ilw
-lnn
-lnn
-lnn
-lnn
-auQ
-lnn
-lnn
-apH
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-cQd
-cQd
-cQd
-cQd
-cQd
-cQd
-cQd
-ylN
-fJU
+san
+hbl
+puh
+puh
+puh
+ada
+ada
+ljo
+ada
+hbl
+puh
+puh
+bzF
+bzF
+xDp
+xDp
+xDp
+xDp
+dxc
+xDp
+xDp
+kUT
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+lyP
+lyP
+lyP
+lyP
+lyP
+lyP
+lyP
+rej
+jwv
 elN
 aBd
 rak
-mhc
+abX
 upU
-fJU
-jrz
-jrz
+jwv
+ngE
+ngE
 bmC
-abV
+yaE
 avB
 fPM
 fPM
 vpG
-abV
-abV
-abV
-abV
-abV
-abV
+yaE
+yaE
+yaE
+yaE
+yaE
+yaE
 bmC
 iSL
 rYw
@@ -47998,7 +47796,7 @@ haj
 kuU
 cOL
 ulA
-vqm
+sWh
 vqm
 acj
 klJ
@@ -48008,18 +47806,18 @@ wWO
 shW
 rHC
 haj
-fsP
-fsP
+puh
+puh
 boS
 lAr
-sLi
-sLi
-cQd
-lnn
-cQd
-cQd
-cQd
-cQd
+tdL
+tdL
+lyP
+xDp
+lyP
+lyP
+lyP
+lyP
 ntv
 ntv
 ntv
@@ -48028,41 +47826,41 @@ ntv
 ntv
 ntv
 ntv
-cQd
-ilw
-ilw
+ccX
+uEJ
+uEJ
 dVE
 aaz
 aaE
-ilw
-dPV
-fsP
-ymg
-ymg
-dPV
-loN
-lnn
-ylN
-ylN
-mVe
-fsP
-ymg
-ymg
-sLi
-ymg
-fsP
-rRK
-qKM
-rRK
-rRK
-biI
-mPR
+uEJ
+ada
+puh
+kqj
+kqj
+ada
+rvZ
+xDp
+rej
+rej
+hbl
+puh
+kqj
+kqj
+tdL
+kqj
+puh
+kLj
+olP
+kLj
+kLj
+jSD
+oLW
 ght
 wNB
-inM
+oHl
 wNB
 wNB
-inM
+oHl
 hbi
 hbi
 xOC
@@ -48089,8 +47887,8 @@ eUz
 eUz
 eUz
 dPz
-bxn
-bxn
+vUL
+vUL
 dPV
 dPV
 dPV
@@ -48098,64 +47896,64 @@ dPV
 xOC
 xOC
 pHC
-dPV
-fsP
-fsP
-ilw
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-ylN
+ada
+puh
+puh
+bzF
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+rej
 sYJ
 ibf
-mhc
-mhc
-mhc
+abX
+abX
+abX
 mlW
-fJU
+jwv
 ngE
 ngE
-abV
+yaE
 vud
-bRO
-bRO
-bRO
-bRO
+acN
+acN
+acN
+acN
 gNb
-abV
-acF
-abV
+yaE
+gbn
+yaE
 jLM
-bRO
-abV
+acN
+yaE
 iSL
 aaf
 tjx
 cOL
 lhz
 ifS
-vqm
+sWh
 vqm
 acj
 fuY
@@ -48165,18 +47963,18 @@ jRN
 jRN
 pcR
 ygR
-mVe
-fsP
-fsP
-ymg
-sLi
-sLi
-ymg
-lnn
-lnn
-lnn
-lnn
-lnn
+hbl
+puh
+puh
+kqj
+tdL
+tdL
+kqj
+xDp
+xDp
+xDp
+xDp
+xDp
 ntv
 dzt
 ptV
@@ -48185,41 +47983,41 @@ pjc
 mzj
 aap
 ntv
-cQd
-ilw
-ilw
+ccX
+uEJ
+uEJ
 nBv
 aaz
-ilw
-ilw
-fsP
-ymg
-ymg
-ymg
-ymg
-mVe
-lnn
-ylN
-ylN
-mVe
-fsP
-fsP
-ymg
-sLi
-ymg
-rRK
-rRK
+uEJ
+uEJ
+puh
+kqj
+kqj
+kqj
+kqj
+hbl
+xDp
 rej
+rej
+hbl
+puh
+puh
+kqj
+tdL
+kqj
+kLj
+kLj
+dFC
 vYw
-rRK
-rRK
-mPR
+kLj
+kLj
+oLW
 qVM
 wNB
 bpz
 wNB
 wNB
-inM
+oHl
 hbi
 hbi
 xOC
@@ -48255,56 +48053,56 @@ dPV
 xOC
 xOC
 xOC
-dPV
-mVe
-fsP
-fsP
-mVe
-lnn
-lnn
-lnn
-lnn
-lnn
-apH
-lnn
-lnn
-lnn
-lnn
-veh
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-ylN
-ylN
+ada
+hbl
+puh
+puh
+hbl
+xDp
+xDp
+xDp
+xDp
+xDp
+kUT
+xDp
+xDp
+xDp
+xDp
+cZg
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+rej
+rej
 sYJ
 vTa
-mhc
-mhc
-mhc
+abX
+abX
+abX
 oGB
-fJU
+jwv
 ngE
 ngE
-abV
+yaE
 uId
 iBc
-bRO
-bRO
+acN
+acN
 eKm
 kcg
-abV
+yaE
 uSv
 bWc
-bRO
-bRO
+acN
+acN
 cty
 iSL
 iSL
@@ -48312,7 +48110,7 @@ tjx
 feq
 kFF
 pFB
-vqm
+sWh
 vqm
 vqm
 ygR
@@ -48323,17 +48121,17 @@ woj
 ygR
 ygR
 fkd
-fsP
-fsP
-mVe
-sLi
-sLi
-ymg
-lnn
-lnn
-lnn
-lnn
-lnn
+puh
+puh
+hbl
+tdL
+tdL
+kqj
+xDp
+xDp
+xDp
+xDp
+xDp
 ntv
 aan
 dzt
@@ -48343,39 +48141,39 @@ dzt
 dzt
 ntv
 aau
-ilw
-ilw
+uEJ
+uEJ
 abl
 abl
 aaF
-cQd
-mVe
-ymg
-ymg
-ymg
-ymg
+ccX
+hbl
+kqj
+kqj
+kqj
+kqj
 abp
 abm
-ylN
-ylN
-lnn
-lnn
-fsP
-ymg
-sLi
-ymg
-rRK
+rej
+rej
+xDp
+xDp
+puh
+kqj
+tdL
+kqj
+kLj
 hxX
-iIt
-rej
-rej
-rRK
+kIk
+dFC
+dFC
+kLj
 uHt
-mPR
-mPR
+oLW
+oLW
 uHt
-mPR
-mPR
+oLW
+oLW
 uHt
 jPW
 jPW
@@ -48412,64 +48210,64 @@ dPV
 dPV
 xOC
 dPV
-omo
-lnn
-fsP
-fsP
-mVe
-dPV
-dPV
-dPV
-dPV
-dPV
-dPV
-dPV
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-ooF
-lnn
-lnn
-lnn
-veh
-lnn
-lnn
-lnn
-lnn
-ylN
-ylN
+uMb
+xDp
+puh
+puh
+hbl
+ada
+ada
+ada
+ada
+ada
+ada
+ada
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+lsY
+xDp
+xDp
+xDp
+cZg
+xDp
+xDp
+xDp
+xDp
+rej
+rej
 sYJ
 gYv
-mhc
-mhc
+abX
+abX
 oOu
 pON
 uHt
 ngE
 ngE
-abV
+yaE
 vmW
-bRO
-bRO
-bRO
-bRO
+acN
+acN
+acN
+acN
 vmW
-abV
-bRO
+yaE
+acN
 krb
-bRO
-bRO
-abV
+acN
+acN
+yaE
 iSL
 iSL
 tjx
 deL
 aEv
 tTH
-vqm
+sWh
 vqm
 vqm
 svu
@@ -48479,18 +48277,18 @@ acj
 acj
 svu
 ygR
-mVe
-fsP
-dVE
-mVe
-sLi
-sLi
-ymg
-lnn
-vIK
-lnn
-lnn
-lnn
+hbl
+puh
+aKS
+hbl
+tdL
+tdL
+kqj
+xDp
+ach
+xDp
+xDp
+xDp
 ntv
 aal
 dzt
@@ -48499,43 +48297,43 @@ dzt
 dzt
 dzt
 aas
-ylN
-cQd
-cQd
-rej
-rej
-cQd
-cQd
-cQd
-cQd
-mVe
+jmN
+ccX
+ccX
+acN
+acN
+ccX
+ccX
+ccX
+ccX
+hbl
 mQR
 wZe
-dPV
-lnn
-ylN
-ylN
-lnn
-bOa
-fsP
-ymg
-sLi
-sLi
-rRK
-rRK
-rRK
+ada
+xDp
+rej
+rej
+xDp
+cHF
+puh
+kqj
+tdL
+tdL
+kLj
+kLj
+kLj
 cGM
-rRK
-rRK
-biI
-biI
-biI
-biI
-biI
-biI
-biI
-biI
-biI
+kLj
+kLj
+jSD
+jSD
+jSD
+jSD
+jSD
+jSD
+jSD
+jSD
+jSD
 xOC
 xOC
 xOC
@@ -48569,64 +48367,64 @@ dPV
 dPV
 dPV
 dPV
-lnn
-dPV
-mVe
-fsP
-mVe
-mVe
-omo
-dPV
-dPV
-abb
-dPV
-dPV
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-bOa
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-ylN
-ylN
-ylN
-ylN
-fJU
+xDp
+ada
+hbl
+puh
+hbl
+hbl
+uMb
+ada
+ada
+iXK
+ada
+ada
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+cHF
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+rej
+rej
+rej
+rej
+jwv
 iPI
-mhc
-mhc
+abX
+abX
 uHt
 tuX
 uHt
 ngE
 ngE
-abV
+yaE
 vzZ
-bRO
-bRO
-bRO
-bRO
+acN
+acN
+acN
+acN
 vzZ
-abV
-abV
-abV
-bRO
-bRO
-abV
+yaE
+yaE
+yaE
+acN
+acN
+yaE
 iSL
 iSL
 ygR
-vqm
-vqm
-vqm
-vqm
+snZ
+snZ
+snZ
+acn
 vqm
 vqm
 ftj
@@ -48636,18 +48434,18 @@ vqm
 vqm
 vqm
 haj
-mVe
-fsP
-fsP
-mVe
-sLi
-sLi
-ymg
-lnn
-lnn
-lnn
-lnn
-lnn
+hbl
+puh
+puh
+hbl
+tdL
+tdL
+kqj
+xDp
+xDp
+xDp
+xDp
+xDp
 ntv
 dzt
 dzt
@@ -48656,42 +48454,42 @@ dzt
 dzt
 dzt
 aas
-ylN
-cQd
+jmN
+ccX
 abh
-rej
-rej
+acN
+acN
 aaI
 hjt
 hjt
-cQd
-mVe
+ccX
+hbl
 abn
-loN
+rvZ
 abm
-ylN
-ylN
-ylN
-lnn
-lnn
-mVe
-ymg
-sLi
-sLi
-sLi
-rRK
-rRK
-rRK
-rRK
-biI
-biI
-biI
-biI
-biI
-biI
-biI
-biI
-biI
+rej
+rej
+rej
+xDp
+xDp
+hbl
+kqj
+tdL
+tdL
+tdL
+kLj
+kLj
+kLj
+kLj
+jSD
+jSD
+jSD
+jSD
+jSD
+jSD
+jSD
+jSD
+jSD
 xOC
 xOC
 xOC
@@ -48726,57 +48524,57 @@ lnn
 dPV
 dPV
 dPV
-lnn
-mVe
-fsP
-fsP
-mVe
-dPV
-dPV
-dPV
-dPV
-dPV
-abb
-dPV
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-ylN
-ylN
-ylN
-vir
-vir
-fJU
+xDp
+hbl
+puh
+puh
+hbl
+ada
+ada
+ada
+ada
+ada
+iXK
+ada
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+rej
+rej
+rej
+hbl
+hbl
+jwv
 iLF
 fHT
 iPI
-fJU
+jwv
 ngE
 ngE
 ngE
 ngE
-abV
+yaE
 gYC
 iBc
-bRO
-bRO
+acN
+acN
 eKm
 gYC
-abV
+yaE
 mUd
 vuV
 vuV
 vuV
-abV
+yaE
 iSL
 iSL
 ygR
@@ -48793,18 +48591,18 @@ haj
 haj
 haj
 haj
-mVe
-fsP
-fsP
-mVe
-sLi
-sLi
-ymg
-ymg
-lnn
-bOa
-lnn
-lnn
+hbl
+puh
+puh
+hbl
+tdL
+tdL
+kqj
+kqj
+xDp
+cHF
+xDp
+xDp
 ntv
 aan
 dzt
@@ -48814,33 +48612,33 @@ dzt
 dzt
 ntv
 aav
-cQd
+ccX
 aba
-rej
-rej
-rej
+acN
+acN
+acN
 aaJ
 hjt
-aaG
-dPV
-dPV
-dPV
-mPR
-ylN
-ylN
+ahG
+ada
+ada
+ada
+san
+rej
+rej
 abg
-ylN
-lnn
-lnn
-ymg
-uSj
-sLi
-sLi
-ymg
-biI
-biI
-biI
-biI
+rej
+xDp
+xDp
+kqj
+kSI
+tdL
+tdL
+kqj
+jSD
+jSD
+jSD
+jSD
 xOC
 xOC
 xOC
@@ -48883,10 +48681,10 @@ qwj
 dPV
 dPV
 omo
-dPV
-mVe
-fsP
-fsP
+ada
+hbl
+puh
+puh
 isk
 ctF
 nQV
@@ -48894,46 +48692,46 @@ nQV
 nQV
 nQV
 ctF
-dPV
-lnn
-lnn
-bOa
-lnn
-lnn
-lnn
-dPV
-dPV
-dPV
-lnn
-bOa
-lnn
-ylN
-ylN
-ylN
-vir
+ada
+xDp
+xDp
+cHF
+xDp
+xDp
+xDp
+ada
+ada
+ada
+xDp
+cHF
+xDp
+rej
+rej
+rej
+hbl
 get
-fJU
+jwv
 khH
 hRv
 xzw
-fJU
+jwv
 ngE
 ngE
 ngE
 ngE
-abV
+yaE
 dez
-bRO
-bRO
-bRO
-bRO
-bRO
+acN
+acN
+acN
+acN
+acN
 oJU
 vuV
 vuV
 vuV
 rVf
-abV
+yaE
 vJn
 iSL
 haj
@@ -48949,19 +48747,19 @@ kjj
 kjj
 kjj
 oNl
-fRr
-mVe
-fsP
-fsP
-ymg
-sLi
-sLi
-ymg
-ymg
-lnn
-lnn
-lnn
-lnn
+pOn
+hbl
+puh
+puh
+kqj
+tdL
+tdL
+kqj
+kqj
+xDp
+xDp
+xDp
+xDp
 ntv
 aao
 dzt
@@ -48970,33 +48768,33 @@ dzt
 dzt
 aar
 ntv
-ylN
+jmN
 gvW
-rej
-rej
-rej
-rej
-rej
-rej
+acN
+acN
+acN
+acN
+acN
+acN
 gvW
 iSL
-ylN
-ylN
+rej
+rej
 tgU
-ylN
-ylN
-ylN
-ylN
+rej
+rej
+rej
+rej
 puV
-ylN
-biI
-ymg
-sLi
-sLi
-ymg
-biI
-biI
-biI
+rej
+jSD
+kqj
+tdL
+tdL
+kqj
+jSD
+jSD
+jSD
 xOC
 xOC
 xOC
@@ -49040,33 +48838,33 @@ dPV
 dPV
 dPV
 bOa
-omo
-mVe
-fsP
+uMb
+hbl
+puh
 eNV
-fsP
-fsP
-fsP
-fsP
-fsP
-fsP
-jPw
-dPV
-lnn
-lnn
-ooF
-lnn
-lnn
-lnn
-jAZ
-dPV
-dPV
-lnn
-lnn
-lnn
-ylN
-ylN
-rWl
+puh
+puh
+puh
+puh
+puh
+puh
+ckv
+ada
+xDp
+xDp
+lsY
+xDp
+xDp
+xDp
+kUM
+ada
+ada
+xDp
+xDp
+xDp
+rej
+rej
+puh
 get
 get
 uHt
@@ -49078,19 +48876,19 @@ ngE
 ngE
 ngE
 ngE
-abV
+yaE
 kSr
-bRO
+acN
 rCp
 rCp
-bRO
+acN
 rCp
-abV
+yaE
 mUd
 vuV
 vuV
 rVf
-abV
+yaE
 ucD
 ucD
 haj
@@ -49106,19 +48904,19 @@ kjj
 kjj
 kjj
 hsN
-mVe
-fsP
-fsP
-mVe
-ymg
-sLi
-sLi
-ymg
-ymg
-lnn
-lnn
-lnn
-lnn
+hbl
+puh
+puh
+hbl
+kqj
+tdL
+tdL
+kqj
+kqj
+xDp
+xDp
+xDp
+xDp
 ntv
 ntv
 ntv
@@ -49127,27 +48925,27 @@ ntv
 ntv
 ntv
 ntv
-cQd
-cQd
+ccX
+ccX
 abi
-rej
+acN
 aaH
-rej
+acN
 aaK
-rej
+acN
 gvW
 iSL
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-biI
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+jSD
 xOC
 xOC
 xOC
@@ -49197,33 +48995,33 @@ dPV
 dPV
 omo
 bOa
-mVe
-fsP
-fsP
-fsP
-kUZ
-kUZ
-kUZ
-kUZ
-kUZ
-kUZ
+hbl
+puh
+puh
+puh
+nCA
+nCA
+nCA
+nCA
+nCA
+nCA
 qIx
-dPV
-lnn
-lnn
-lnn
-ooF
-lnn
-lnn
-dPV
-dPV
-dPV
-lnn
-lnn
-lnn
-ylN
-ylN
-vir
+ada
+xDp
+xDp
+xDp
+lsY
+xDp
+xDp
+ada
+ada
+ada
+xDp
+xDp
+xDp
+rej
+rej
+hbl
 get
 get
 abk
@@ -49235,19 +49033,19 @@ abk
 abk
 ngE
 ngE
-abV
-rPp
-rPp
+yaE
+qGr
+qGr
 rCp
 rCp
-bRO
+acN
 xOt
-abV
+yaE
 ngL
 vuV
 vuV
 vxC
-abV
+yaE
 abk
 abk
 abk
@@ -49263,45 +49061,45 @@ kjj
 kjj
 kjj
 hsN
-mVe
-fsP
-fsP
-mVe
-ymg
-sLi
-sLi
-sLi
-ymg
-vIK
-lnn
-lnn
-dPV
-cQd
-mPR
-mPR
-cQd
-lnn
-lnn
-lnn
-lnn
-lnn
-cQd
+hbl
+puh
+puh
+hbl
+kqj
+tdL
+tdL
+tdL
+kqj
+ach
+xDp
+xDp
+ada
+cUB
+dsB
+dsB
+cUB
+xDp
+xDp
+xDp
+xDp
+xDp
+ccX
 wza
 hjt
 wPI
 hjt
 wPI
 pIl
-cQd
+ccX
 lNY
-ylN
-ylN
-ylN
-ylN
+rej
+rej
+rej
+rej
 abg
-ylN
-fsP
-fsP
+rej
+puh
+puh
 nQr
 tOR
 phy
@@ -49354,33 +49152,33 @@ dPV
 lnn
 omo
 omo
-mVe
-fsP
-fsP
+hbl
+puh
+puh
 eNV
-fsP
-fsP
-fsP
-fsP
-fsP
-fsP
-fsP
+puh
+puh
+puh
+puh
+puh
+puh
+puh
 rRK
 rRK
 rRK
-dPV
-dPV
-dPV
-lnn
-dPV
-dPV
-dPV
-lnn
-lnn
-ylN
-ylN
-ylN
-vir
+ada
+ada
+ada
+xDp
+ada
+ada
+ada
+xDp
+xDp
+rej
+rej
+rej
+hbl
 cBC
 get
 get
@@ -49393,17 +49191,17 @@ abk
 abk
 abk
 bmC
-abV
+yaE
 ngx
-abV
-abV
+yaE
+yaE
 ngx
-abV
-abV
-abV
+yaE
+yaE
+yaE
 ngx
 ngx
-abV
+yaE
 bmC
 abk
 abk
@@ -49420,47 +49218,47 @@ kjj
 kjj
 kjj
 hsN
-fRr
-fsP
-fsP
-mVe
-ymg
-uSj
-sLi
-sLi
-ymg
-lnn
-lnn
-lnn
-lnn
-mPR
+pOn
+puh
+puh
+hbl
+kqj
+kSI
+tdL
+tdL
+kqj
+xDp
+xDp
+xDp
+xDp
+dsB
 haC
 mBT
-mPR
-lnn
-lnn
-lnn
-lnn
-lnn
-cQd
+dsB
+xDp
+xDp
+xDp
+xDp
+xDp
+ccX
 gvW
-cQd
-cQd
+ccX
+ccX
 bYR
-cQd
-cQd
-cQd
+ccX
+ccX
+ccX
 aco
-ylN
+rej
 abg
 goi
-ylN
-ylN
-ylN
-fsP
-fsP
-jPw
-xOC
+rej
+rej
+rej
+puh
+puh
+ckv
+ljo
 phy
 xOC
 xOC
@@ -49511,10 +49309,10 @@ abb
 lnn
 dPV
 dPV
-mVe
-mVe
-fsP
-fsP
+hbl
+hbl
+puh
+puh
 vfN
 dao
 dao
@@ -49527,15 +49325,15 @@ cij
 cij
 rRK
 rRK
-dPV
-lnn
-dPV
-dPV
-ayX
-lnn
-lnn
-ylN
-ylN
+ada
+xDp
+ada
+ada
+lzU
+xDp
+xDp
+rej
+rej
 piD
 cBC
 cBC
@@ -49577,48 +49375,48 @@ kjj
 kjj
 kjj
 hsN
-fRr
-mVe
-fsP
-spZ
-ymg
-uSj
-sLi
-sLi
-ymg
-ymg
-lnn
-lnn
-lnn
-mPR
-rej
-rej
-mPR
-lnn
-lnn
-lnn
-lnn
-lnn
+pOn
+hbl
+puh
+bJz
+kqj
+kSI
+tdL
+tdL
+kqj
+kqj
+xDp
+xDp
+xDp
+dsB
+dFC
+dFC
+dsB
+xDp
+xDp
+xDp
+xDp
+xDp
 utD
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-mPR
-ylN
-ylN
-ylN
-ylN
-fsP
-fsP
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+san
+rej
+rej
+rej
+rej
+puh
+puh
 ngR
-fsP
+puh
 xOC
 xOC
 xOC
@@ -49668,14 +49466,14 @@ dPV
 dPV
 dPV
 dPV
-dPV
-mVe
-fsP
-fsP
-mVe
-lnn
-lnn
-lnn
+ada
+hbl
+puh
+puh
+hbl
+xDp
+xDp
+xDp
 rRK
 rRK
 cij
@@ -49685,15 +49483,15 @@ evH
 cij
 rRK
 rRK
-dPV
-dPV
-dPV
-ayX
-dPV
-apH
-ylN
-ylN
-mVe
+ada
+ada
+ada
+lzU
+ada
+kUT
+rej
+rej
+hbl
 adg
 adg
 adg
@@ -49734,47 +49532,47 @@ gFz
 gFz
 gFz
 oVz
-mVe
-fsP
-fsP
-ymg
-ymg
-uSj
-uSj
-sLi
-sLi
-ymg
-lnn
-lnn
-lnn
-cQd
+hbl
+puh
+puh
+kqj
+kqj
+kSI
+kSI
+tdL
+tdL
+kqj
+xDp
+xDp
+xDp
+cUB
 fQo
-mPR
-cQd
-lnn
-lnn
-lnn
-lnn
-lnn
+dsB
+cUB
+xDp
+xDp
+xDp
+xDp
+xDp
 utD
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-dPV
-dPV
-ylN
-ylN
-ylN
-ylN
-fsP
-fsP
-fsP
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+ada
+ada
+rej
+rej
+rej
+rej
+puh
+puh
+puh
 xOC
 xOC
 xOC
@@ -49825,32 +49623,32 @@ dPV
 dPV
 dPV
 dPV
-mVe
-fsP
-fsP
-fsP
-mVe
-mVe
-mVe
+hbl
+puh
+puh
+puh
+hbl
+hbl
+hbl
 rRK
 rRK
 cij
 leI
-kzW
-kzW
-kzW
+hHC
+hHC
+hHC
 ldA
 cij
 rRK
 rRK
-dPV
-dPV
-lnn
-lnn
-lnn
-ylN
-ylN
-biI
+ada
+ada
+xDp
+xDp
+xDp
+rej
+rej
+jSD
 adg
 adg
 adg
@@ -49891,47 +49689,47 @@ uXf
 uXf
 aqr
 aqr
-fsP
-fsP
-fsP
-ymg
-ymg
-uSj
-uSj
-sLi
-sLi
-ymg
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-bOa
-lnn
-lnn
-ylN
+puh
+puh
+puh
+kqj
+kqj
+kSI
+kSI
+tdL
+tdL
+kqj
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+cHF
+xDp
+xDp
+rej
 oLW
 oLW
 oLW
 oLW
 oLW
 oLW
-iPW
-iPW
-iPW
-dPV
-ylN
-ylN
-ylN
-ylN
+cij
+cij
+cij
+ada
+rej
+rej
+rej
+rej
 wjg
-fsP
-fsP
+puh
+puh
 xOC
 xOC
 xOC
@@ -49982,31 +49780,31 @@ dPV
 dPV
 pHC
 dPV
-mVe
-fsP
-fsP
-fsP
-fsP
-fsP
-mVe
+hbl
+puh
+puh
+puh
+puh
+puh
+hbl
 rRK
 cij
-kzW
-kzW
+hHC
+hHC
 irY
 irY
 irY
-kzW
-kzW
+hHC
+hHC
 cij
 rRK
-dPV
-dPV
-rRK
-lnn
-lnn
-ylN
-ylN
+ada
+ada
+fdy
+xDp
+xDp
+rej
+rej
 cBC
 adg
 adg
@@ -50044,51 +49842,51 @@ abk
 abk
 abk
 abk
-kzW
-kzW
-fsP
-fsP
-fsP
-fsP
-mVe
-fRr
-ymg
-uSj
-uSj
+rJC
+rJC
+puh
+puh
+puh
+puh
+hbl
+pOn
+kqj
+kSI
+kSI
 eAz
-sLi
-ymg
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
+tdL
+kqj
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
 utD
-ylN
+rej
 oLW
 dGF
 vkn
 oLW
-aKS
+fOB
 dzE
 jaR
-rPp
-iPW
-dPV
-dPV
-ylN
-ylN
+qGr
+cij
+ada
+ada
+rej
+rej
 sxT
-mPR
-fsP
-fsP
+san
+puh
+puh
 xOC
 xOC
 xOC
@@ -50139,30 +49937,30 @@ dPV
 dPV
 dPV
 dPV
-mVe
-fsP
-fsP
-fsP
-fsP
-fsP
-fsP
+hbl
+puh
+puh
+puh
+puh
+puh
+puh
 qpT
-kzW
-kzW
-kzW
+hHC
+hHC
+hHC
 ptg
 mZr
 wJf
-kzW
+hHC
 vJN
 cij
 rRK
-dPV
-dPV
-lnn
-lnn
-lnn
-ylN
+ada
+ada
+xDp
+xDp
+xDp
+rej
 aYy
 cBC
 cBC
@@ -50201,51 +49999,51 @@ abk
 abk
 abk
 wtR
-kzW
-kzW
-fsP
-fsP
-mVe
-mVe
-fRr
-fRr
-ymg
-uSj
-uSj
-sLi
-sLi
-ymg
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
+rJC
+rJC
+puh
+puh
+hbl
+hbl
+pOn
+pOn
+kqj
+kSI
+kSI
+tdL
+tdL
+kqj
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
 utD
-ylN
+rej
 oLW
 iFY
 fZj
 oLW
-kLK
+iVJ
 fdv
-bRO
+acN
 dlX
-jmO
-dPV
-dPV
-ylN
-ylN
+lwR
+ada
+ada
+rej
+rej
 gSm
 duZ
-xOC
-xOC
+ljo
+ljo
 xOC
 xOC
 btI
@@ -50296,30 +50094,30 @@ lnn
 dPV
 dPV
 mVe
-mVe
-fsP
-fsP
-fsP
+hbl
+puh
+puh
+puh
 bKO
-mVe
-mVe
+hbl
+hbl
 rRK
 cij
-kzW
-kzW
+hHC
+hHC
 vHI
 vHI
 vHI
-kzW
-kzW
+hHC
+hHC
 cij
 rRK
-dPV
-dPV
-rRK
-fsP
-mVe
-fsP
+ada
+ada
+fdy
+puh
+hbl
+puh
 cBC
 adg
 adg
@@ -50358,50 +50156,50 @@ abk
 abk
 abk
 abk
-kzW
-kzW
-mVe
-mVe
-fRr
-fRr
-fRr
-lnn
-lnn
-sLi
-sLi
-sLi
-sLi
-ymg
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
+rJC
+rJC
+hbl
+hbl
+pOn
+pOn
+pOn
+xDp
+xDp
+tdL
+tdL
+tdL
+tdL
+kqj
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
 utD
-ylN
+rej
 oLW
-rDz
-rDz
-uEJ
-rDz
+sPC
+sPC
+mtb
+sPC
 fzT
-bRO
-iXK
-iPW
-dPV
-mVe
-ylN
-ylN
+acN
+ydI
+cij
+ada
+hbl
+rej
+rej
 gSm
 hpn
-xOC
+ljo
 xOC
 xOC
 xOC
@@ -50464,14 +50262,14 @@ rRK
 rRK
 cij
 leI
-kzW
-kzW
-kzW
+hHC
+hHC
+hHC
 hVT
 cij
 rRK
 rRK
-dPV
+ada
 cBC
 cBC
 khL
@@ -50515,47 +50313,47 @@ abk
 abk
 abk
 kXt
-kzW
-mxw
-lyQ
+rJC
+fOW
+dxV
 iwW
 cWP
 cWP
 cWP
-lnn
-lnn
-sLi
-sLi
-sLi
-sLi
-uGz
-lnn
-lnn
-cQd
+xDp
+xDp
+tdL
+tdL
+tdL
+tdL
+age
+xDp
+xDp
+ccX
 mVs
-cQd
-cQd
-cQd
-cQd
-cQd
-cQd
-cQd
-cQd
-cQd
-ylN
+ccX
+ccX
+ccX
+ccX
+ccX
+ccX
+ccX
+ccX
+ccX
+rej
 oLW
-jSD
+whv
 cBU
-iPW
-fdy
+cij
+nka
 pAw
-bRO
-bRO
-iPW
-mVe
-mVe
-ylN
-ylN
+acN
+acN
+cij
+hbl
+hbl
+rej
+rej
 gSm
 hpn
 xOC
@@ -50591,11 +50389,11 @@ xOC
 (91,1,2) = {"
 eUz
 eUz
-hfa
+eUz
 eUz
 eUz
 jMT
-jHG
+jMT
 apG
 biI
 dPz
@@ -50671,48 +50469,48 @@ abk
 abk
 abk
 abk
-aat
+ccX
 owU
-aat
-aat
-aat
+ccX
+ccX
+ccX
 rFn
-aat
+ccX
 rFn
 rFn
-aat
-sLi
-sLi
-sLi
-sLi
-uGz
-bOa
-lnn
-cQd
-bGi
+ccX
+tdL
+tdL
+tdL
+tdL
+age
+cHF
+xDp
+ccX
+hSx
 bYu
-cQd
+ccX
 wra
 bYu
 xPB
-cQd
+ccX
 xXw
 akb
-cQd
-ylN
+ccX
+rej
 oLW
 oLW
-iPW
-iPW
-iPW
-iPW
-kLj
-iPW
-iPW
-mVe
-mVe
-ylN
-ylN
+cij
+cij
+cij
+cij
+qKM
+cij
+cij
+hbl
+hbl
+rej
+rej
 gSm
 gVB
 xOC
@@ -50751,7 +50549,7 @@ eUz
 eUz
 eUz
 vTH
-jHG
+jMT
 nAs
 biI
 biI
@@ -50831,47 +50629,47 @@ abk
 rFn
 hHC
 hHC
-aat
+ccX
 jVy
 hHC
 hHC
-ade
+kUZ
 xgy
 wmf
-sLi
-sLi
-sLi
-uGz
-uGz
-ymg
-lnn
+tdL
+tdL
+tdL
+age
+age
+kqj
+xDp
 uJQ
-bGi
-bGi
-cQd
+hSx
+hSx
+ccX
 bWn
-bGi
+hSx
 pzg
-cQd
+ccX
 mxw
 mxw
-cQd
-ylN
-ylN
+ccX
+rej
+rej
 lty
-iPW
-jwC
+cij
+vFM
 pnv
-jwC
-bRO
-bRO
-iPW
+vFM
+acN
+acN
+cij
 kgO
-ylN
-ylN
-ylN
+rej
+rej
+rej
 gSm
-mPR
+san
 xOC
 xOC
 xOC
@@ -50985,47 +50783,47 @@ abk
 abk
 abk
 abk
-aat
+ccX
 hHC
 hHC
 hJj
 hJj
 hHC
 hHC
-ade
+kUZ
 hLv
-aat
+ccX
 eAz
-sLi
-sLi
-uGz
-sLi
-ymg
-lnn
-cQd
+tdL
+tdL
+age
+tdL
+kqj
+xDp
+ccX
 uig
 aaq
-cQd
+ccX
 lrV
-bGi
-bGi
-cQd
-kzW
-kzW
+hSx
+hSx
+ccX
+hHC
+hHC
 hdr
-ylN
-ylN
+rej
+rej
 lty
-jmO
-jwC
+lwR
+vFM
 gkl
 cEq
-bRO
-bRO
+acN
+acN
 slK
-ylN
-ylN
-ylN
+rej
+rej
+rej
 kov
 dZj
 lvL
@@ -51142,50 +50940,50 @@ get
 hQe
 abk
 abk
-aat
+ccX
 gWx
 hHC
 hHC
 hHC
 hHC
 rZT
-ade
+kUZ
 gFS
-aat
-sLi
-sLi
-uGz
-sLi
-sLi
-ymg
-lnn
-cQd
-bGi
-bGi
-cQd
-cQd
-lyP
-cQd
-cQd
-kzW
-kzW
+ccX
+tdL
+tdL
+age
+tdL
+tdL
+kqj
+xDp
+ccX
+hSx
+hSx
+ccX
+ccX
+twA
+ccX
+ccX
+hHC
+hHC
 vUw
-ylN
-ylN
+rej
+rej
 lty
 oLW
 xZW
 gkl
-jwC
-bRO
+vFM
+acN
 lHP
-iPW
-ylN
-ylN
-ylN
-mDW
-mDW
-mDW
+cij
+rej
+rej
+rej
+dwh
+dwh
+dwh
 mNh
 mNh
 mNh
@@ -51306,43 +51104,43 @@ hHC
 hHC
 hHC
 mwP
-ade
+kUZ
 vNx
 rFn
-sLi
-sLi
-sLi
-sLi
-sLi
-bOa
-lnn
-cQd
+tdL
+tdL
+tdL
+tdL
+tdL
+cHF
+xDp
+ccX
 kGa
 tRo
-bGi
-kzW
-kzW
-kzW
-kzW
-kzW
-kzW
+hSx
+hHC
+hHC
+hHC
+hHC
+hHC
+hHC
 hdr
-ylN
-ylN
+rej
+rej
 laz
-jmO
-jwC
+lwR
+vFM
 gkl
-jwC
-bRO
-rPp
-iPW
-mVe
-ylN
-ylN
-mDW
-mDW
-mDW
+vFM
+acN
+qGr
+cij
+hbl
+rej
+rej
+dwh
+dwh
+dwh
 mNh
 mNh
 mNh
@@ -51456,47 +51254,47 @@ cBC
 cBC
 cBC
 sHp
-aat
+ccX
 rFn
 rFn
-aat
-aat
+ccX
+ccX
 rFn
-aat
-aat
-aat
-aat
-sLi
-sLi
-sLi
-sLi
-uGz
-lnn
-lnn
-cQd
+ccX
+ccX
+ccX
+ccX
+tdL
+tdL
+tdL
+tdL
+age
+xDp
+xDp
+ccX
 qky
 tRo
-bGi
-kzW
-kzW
-kzW
+hSx
+hHC
+hHC
+hHC
 mxw
 mxw
-kzW
-cQd
-ylN
-ylN
+hHC
+ccX
+rej
+rej
 laz
-iPW
+cij
 wnS
 lHX
 bja
-bRO
+acN
 vKq
-iPW
-dPV
+cij
+ada
 kWX
-ylN
+rej
 sDO
 rPu
 pGZ
@@ -51623,40 +51421,40 @@ tVm
 tVm
 cBC
 cBC
-sLi
-sLi
-sLi
-sLi
-sLi
-ymg
-lnn
-cQd
-cQd
-dDS
-kzW
-cQd
-kzW
+tdL
+tdL
+tdL
+tdL
+tdL
+kqj
+xDp
+ccX
+ccX
+mpl
+hHC
+ccX
+hHC
 cNw
 htL
 htL
-kzW
-cQd
-ylN
-ylN
+hHC
+ccX
+rej
+rej
 dVQ
-iPW
-iPW
-iPW
+cij
+cij
+cij
 nVS
-nCA
-bRO
-iPW
-dPV
+gdD
+acN
+cij
+ada
 rhJ
-ylN
+rej
 gSm
 hpn
-mPR
+san
 xOC
 xOC
 xOC
@@ -51780,40 +51578,40 @@ tVm
 cBC
 cBC
 cBC
-sLi
-sLi
-sLi
-sLi
-sLi
-ymg
-lnn
-cQd
+tdL
+tdL
+tdL
+tdL
+tdL
+kqj
+xDp
+ccX
 rGG
-kzW
+hHC
 rGG
-cQd
-kzW
+ccX
+hHC
 dQZ
 dQZ
 dQZ
-kzW
-cQd
-ylN
-ylN
+hHC
+ccX
+rej
+rej
 lty
-iPW
+cij
 kal
-iPW
-acF
+cij
+gbn
 qRR
-bRO
-iPW
-vjT
-ylN
-ylN
+acN
+cij
+rUT
+rej
+rej
 gSm
 hpn
-nMa
+ayZ
 xOC
 xOC
 xOC
@@ -51851,8 +51649,8 @@ vTH
 vTH
 vTH
 vTH
-ktr
-lAV
+dPz
+biI
 apG
 dPz
 eUz
@@ -51937,40 +51735,40 @@ cBC
 cBC
 cBC
 cBC
-sLi
-sLi
-sLi
-sLi
-ymg
-lnn
-lnn
-cQd
+tdL
+tdL
+tdL
+tdL
+kqj
+xDp
+xDp
+ccX
 fPC
 nQp
 htL
-cQd
+ccX
 tGZ
 foU
 etP
 foU
 uJx
-cQd
-ylN
-ylN
+ccX
+rej
+rej
 lty
-iPW
+cij
 ajr
-iPW
-iPW
-jmO
-iPW
-iPW
-dPV
-ylN
-ylN
+cij
+cij
+lwR
+cij
+cij
+ada
+rej
+rej
 gSm
 hpn
-xOC
+ljo
 xOC
 xOC
 xOC
@@ -52094,40 +51892,40 @@ cBC
 cBC
 cBC
 nBe
-sLi
-sLi
-sLi
-sLi
-lnn
-iFR
-lnn
-cQd
-cQd
-cQd
-cQd
-cQd
-cQd
-cQd
-cQd
-cQd
+tdL
+tdL
+tdL
+tdL
+xDp
+uEG
+xDp
+ccX
+ccX
+ccX
+ccX
+ccX
+ccX
+ccX
+ccX
+ccX
 ngd
-cQd
-ylN
-ylN
+ccX
+rej
+rej
 lty
-dPV
-dPV
-dPV
-dPV
-dPV
-dPV
-jzM
-ylN
-ylN
-ylN
+ada
+ada
+ada
+ada
+ada
+ada
+aaG
+rej
+rej
+rej
 gSm
 hpn
-xOC
+ljo
 xOC
 xOC
 xOC
@@ -52251,37 +52049,37 @@ tVm
 cBC
 cBC
 nBe
-sLi
-sLi
-sLi
-ymg
-dXm
-lnn
-lnn
-dPV
-dPV
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-bOa
-lnn
+tdL
+tdL
+tdL
+kqj
+pSx
+xDp
+xDp
+ada
+ada
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+cHF
+xDp
 utD
-ylN
-ylN
+rej
+rej
 lty
-omo
-dPV
-dPV
-omo
-dPV
+uMb
+ada
+ada
+uMb
+ada
 vWW
-fsP
+puh
 puV
-ylN
-ylN
+rej
+rej
 gSm
 hpn
 mEm
@@ -52408,40 +52206,40 @@ tVm
 tVm
 nBe
 ozU
-sLi
-sLi
-sLi
-ymg
-dPV
-dPV
-dPV
-dPV
-dPV
-lnn
-lnn
-lnn
-lnn
-lnn
-vIK
-lnn
-lnn
+tdL
+tdL
+tdL
+kqj
+ada
+ada
+ada
+ada
+ada
+xDp
+xDp
+xDp
+xDp
+xDp
+ach
+xDp
+xDp
 utD
-ylN
-ylN
+rej
+rej
 lty
-dPV
-dPV
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
+ada
+ada
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
 gSm
 hpn
-mPR
+san
 xOC
 xOC
 xOC
@@ -52565,36 +52363,36 @@ jzs
 tVm
 tVm
 adg
-sLi
-sLi
-uGz
-iPW
-aat
-aat
-aat
-iPW
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
+tdL
+tdL
+age
+cij
+ccX
+ccX
+ccX
+cij
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
 utD
-ylN
-ylN
+rej
+rej
 lty
-fsP
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
+puh
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
 sxT
 uts
 hpn
@@ -52722,29 +52520,29 @@ tVm
 cBC
 adg
 cBC
-sLi
-sLi
-uGz
-aat
+tdL
+tdL
+age
+ccX
 wgT
 gIY
 gVZ
-aat
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
+ccX
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
 utD
-ylN
-ylN
+rej
+rej
 lty
-ylN
-ylN
+rej
+rej
 sxT
 iGv
 iGv
@@ -52753,8 +52551,8 @@ iGv
 iGv
 iGv
 xRJ
-mPR
-mPR
+san
+san
 xOC
 xOC
 xOC
@@ -52879,29 +52677,29 @@ get
 cBC
 adg
 cBC
-sLi
-sLi
+tdL
+tdL
 lNu
-aat
+ccX
 fsg
-vUL
+mDW
 cKx
-aat
-dPV
-dPV
-lnn
-lnn
-lnn
-lnn
-lnn
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
+ccX
+ada
+ada
+xDp
+xDp
+xDp
+xDp
+xDp
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
 abR
 gLg
 gLg
@@ -52910,7 +52708,7 @@ gLg
 gLg
 gLg
 gLg
-mPR
+san
 xOC
 xOC
 xOC
@@ -53036,36 +52834,36 @@ cBC
 adg
 adg
 cBC
-sLi
-sLi
-lnn
-aat
+tdL
+tdL
+xDp
+ccX
 ttS
-vUL
-vUL
-aat
-dPV
-dPV
-lnn
-lnn
-vIK
-lnn
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
+mDW
+mDW
+ccX
+ada
+ada
+xDp
+xDp
+ach
+xDp
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
 abS
-mPR
-fsD
-xOC
-xOC
-xOC
-mPR
+san
+iIt
+ljo
+ljo
+ljo
+san
 fsD
 xOC
 xOC
@@ -53193,28 +52991,28 @@ get
 adg
 cBC
 cBC
-sLi
-sLi
-lnn
-iPW
-aat
+tdL
+tdL
+xDp
+cij
+ccX
 prs
-aat
-iPW
-aat
-aat
-iPW
+ccX
+cij
+ccX
+ccX
+cij
 dLf
-lnn
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
+xDp
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
+rej
 abP
 xOC
 xOC
@@ -53350,27 +53148,27 @@ get
 tVm
 cBC
 cBC
-sLi
-sLi
-lnn
-aat
+tdL
+tdL
+xDp
+ccX
 mLx
-vUL
-vUL
+mDW
+mDW
 pQq
-vUL
-vUL
-aat
+mDW
+mDW
+ccX
 rfI
-ylN
-ylN
-ylN
-ylN
+rej
+rej
+rej
+rej
 xeq
-lnn
-biI
-biI
-biI
+xDp
+jSD
+jSD
+jSD
 abO
 xOC
 xOC
@@ -53507,26 +53305,26 @@ sHp
 tVm
 cBC
 hKA
-sLi
+tdL
 eAz
-lnn
+xDp
 mee
 qew
-vUL
+mDW
 jrj
 kwz
-vUL
-vUL
+mDW
+mDW
 ymi
-ylN
-ylN
-ylN
-ylN
-ylN
-lnn
-biI
-biI
-biI
+rej
+rej
+rej
+rej
+rej
+xDp
+jSD
+jSD
+jSD
 abK
 xOC
 xOC
@@ -53664,26 +53462,26 @@ get
 cBC
 adg
 hKA
-sLi
-sLi
-lnn
-aat
+tdL
+tdL
+xDp
+ccX
 dPb
-vUL
-vUL
+mDW
+mDW
 kwz
-vUL
+mDW
 gIY
 mee
-lnn
-ylN
-ylN
-ylN
-lnn
-biI
-biI
-biI
-biI
+xDp
+rej
+rej
+rej
+xDp
+jSD
+jSD
+jSD
+jSD
 abK
 xOC
 xOC
@@ -53821,26 +53619,26 @@ cBC
 adg
 adg
 hKA
-sLi
-sLi
-lnn
-aat
+tdL
+tdL
+xDp
+ccX
 ueX
-vUL
-vUL
+mDW
+mDW
 xCL
-vUL
+mDW
 gIY
-aat
-lnn
-ylN
-ylN
-ylN
-lnn
-biI
-biI
-biI
-biI
+ccX
+xDp
+rej
+rej
+rej
+xDp
+jSD
+jSD
+jSD
+jSD
 jfy
 xOC
 xOC
@@ -53978,27 +53776,27 @@ adg
 adg
 cBC
 hKA
-sLi
-sLi
-dPV
-iPW
+tdL
+tdL
+ada
+cij
 puf
 ocP
 rJt
-iPW
-aat
-aat
-iPW
-lnn
-ylN
-ylN
-lnn
-dXm
-biI
-biI
+cij
+ccX
+ccX
+cij
+xDp
+rej
+rej
+xDp
+pSx
+jSD
+jSD
 abL
 abN
-xOC
+ljo
 xOC
 xOC
 xOC
@@ -54135,27 +53933,27 @@ adg
 cBC
 cBC
 pbj
-sLi
-sLi
-dPV
-iPW
-aat
-aat
-aat
-iPW
-lnn
-lnn
-lnn
-lnn
-ylN
-ylN
-lnn
-lnn
-biI
+tdL
+tdL
+ada
+cij
+ccX
+ccX
+ccX
+cij
+xDp
+xDp
+xDp
+xDp
+rej
+rej
+xDp
+xDp
+jSD
 abK
-xOC
-xOC
-xOC
+ljo
+ljo
+ljo
 xOC
 abT
 xOC
@@ -54291,30 +54089,30 @@ cBC
 cBC
 cBC
 tVm
-sLi
-sLi
-sLi
-ymg
-dPV
-dPV
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-ylN
-ylN
-lnn
-lnn
-biI
+naq
+tdL
+tdL
+kqj
+ada
+ada
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+rej
+rej
+xDp
+xDp
+jSD
 abK
-xOC
-xOC
-xOC
-mPR
-biI
+ljo
+ljo
+ljo
+san
+jSD
 xOC
 xOC
 xOC
@@ -54448,30 +54246,30 @@ vir
 cBC
 adn
 tVm
-sLi
-sLi
-sLi
-ymg
-ymg
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-ylN
-ylN
-lnn
-lnn
-biI
+naq
+tdL
+tdL
+kqj
+kqj
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+rej
+rej
+xDp
+xDp
+jSD
 abK
-xOC
-xOC
-xOC
-fsP
-biI
+ljo
+ljo
+ljo
+puh
+jSD
 xOC
 xOC
 xOC
@@ -54605,30 +54403,30 @@ get
 vir
 tVm
 tVm
-sLi
-sLi
-sLi
-ymg
-ymg
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-ylN
-ylN
-lnn
-lnn
-biI
+naq
+tdL
+tdL
+kqj
+kqj
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+rej
+rej
+xDp
+xDp
+jSD
 abK
-xOC
-xOC
-xOC
-xOC
-xOC
+ljo
+ljo
+ljo
+ljo
+ljo
 xOC
 xOC
 xOC
@@ -54764,23 +54562,23 @@ vir
 tVm
 naq
 eAz
-sLi
-ymg
-ymg
-lnn
-lnn
-lnn
-lnn
-apH
-lnn
-lnn
-lnn
-ylN
-ylN
-auQ
-lnn
-biI
-biI
+tdL
+kqj
+kqj
+xDp
+xDp
+xDp
+xDp
+kUT
+xDp
+xDp
+xDp
+rej
+rej
+dxc
+xDp
+jSD
+jSD
 abM
 abM
 abM
@@ -54920,27 +54718,27 @@ vir
 cBC
 cBC
 naq
-sLi
-sLi
+tdL
+tdL
 mms
-lnn
-lnn
-lnn
-vIK
-lnn
-lnn
-lnn
-apH
-ylN
-ylN
-ylN
-lnn
-lnn
-biI
-biI
-biI
-biI
-fsP
+xDp
+xDp
+xDp
+ach
+xDp
+xDp
+xDp
+kUT
+rej
+rej
+rej
+xDp
+xDp
+jSD
+jSD
+jSD
+jSD
+puh
 abK
 xOC
 xOC
@@ -55077,27 +54875,27 @@ cBC
 cBC
 adg
 naq
-sLi
-sLi
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-ylN
-ylN
-ylN
-lnn
-lnn
-biI
-biI
-biI
-biI
-biI
+tdL
+tdL
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+rej
+rej
+rej
+xDp
+xDp
+jSD
+jSD
+jSD
+jSD
+jSD
 abN
 xOC
 xOC
@@ -55234,26 +55032,26 @@ adg
 adg
 adg
 naq
-sLi
-sLi
-ymg
-ymg
-lnn
-lnn
-bOa
-lnn
-lnn
-lnn
-lnn
-ylN
-ylN
+tdL
+tdL
+kqj
+kqj
+xDp
+xDp
+cHF
+xDp
+xDp
+xDp
+xDp
+rej
+rej
 xeq
-lnn
-lnn
-biI
-biI
-biI
-biI
+xDp
+xDp
+jSD
+jSD
+jSD
+jSD
 abK
 xOC
 xOC
@@ -55391,26 +55189,26 @@ adg
 adg
 cBC
 sLi
-sLi
-sLi
-ymg
-ymg
-ymg
-lnn
-lnn
-lnn
-lnn
-lnn
-lnn
-ylN
-ylN
-lnn
-lnn
-lnn
-biI
-biI
-biI
-biI
+tdL
+tdL
+kqj
+kqj
+kqj
+xDp
+xDp
+xDp
+xDp
+xDp
+xDp
+rej
+rej
+xDp
+xDp
+xDp
+jSD
+jSD
+jSD
+jSD
 abK
 xOC
 xOC
@@ -55548,26 +55346,26 @@ adg
 cBC
 cBC
 sLi
-sLi
-sLi
-ymg
-lnn
-apH
-lnn
-lnn
-lnn
-lnn
-lnn
+tdL
+tdL
+kqj
+xDp
+kUT
+xDp
+xDp
+xDp
+xDp
+xDp
 mab
-ylN
-ylN
-lnn
-vIK
-lnn
-biI
-biI
-biI
-biI
+rej
+rej
+xDp
+ach
+xDp
+jSD
+jSD
+jSD
+jSD
 abK
 xOC
 xOC
@@ -55705,26 +55503,26 @@ adg
 cBC
 lnn
 sLi
-sLi
-sLi
-ymg
-lnn
-lnn
-lnn
-lnn
-bOa
-lnn
-ylN
-ylN
-ylN
-ylN
-lnn
-lnn
-biI
-biI
-biI
-biI
-biI
+tdL
+tdL
+kqj
+xDp
+xDp
+xDp
+xDp
+cHF
+xDp
+rej
+rej
+rej
+rej
+xDp
+xDp
+jSD
+jSD
+jSD
+jSD
+jSD
 vTH
 xOC
 xOC
@@ -55862,26 +55660,26 @@ adg
 lnn
 bOa
 sLi
-sLi
-sLi
-ymg
-lnn
-lnn
-lnn
-ylN
-ylN
-ylN
-ylN
-ylN
-ylN
-lnn
-biI
-biI
-biI
-biI
-biI
-biI
-biI
+tdL
+tdL
+kqj
+xDp
+xDp
+xDp
+rej
+rej
+rej
+rej
+rej
+rej
+xDp
+jSD
+jSD
+jSD
+jSD
+jSD
+jSD
+jSD
 vTH
 xOC
 xOC
@@ -55953,8 +55751,8 @@ sHp
 tVm
 adg
 adg
-lAV
-lAV
+get
+get
 adg
 adg
 adg
@@ -56020,25 +55818,25 @@ lnn
 ymg
 sLi
 sLi
-sLi
-ymg
-lnn
-lnn
-ylN
-ylN
-ylN
-ylN
-ylN
-lnn
-lnn
-lnn
-biI
-biI
-biI
-biI
-biI
-biI
-biI
+tdL
+kqj
+xDp
+xDp
+rej
+rej
+rej
+rej
+rej
+xDp
+xDp
+xDp
+jSD
+jSD
+jSD
+jSD
+jSD
+jSD
+jSD
 vTH
 vTH
 vTH
@@ -56046,12 +55844,12 @@ xOC
 kdK
 kdK
 dSE
-pOn
-pOn
-pOn
-pOn
-pOn
-pOn
+kdK
+kdK
+kdK
+kdK
+kdK
+kdK
 xOC
 xOC
 xOC
@@ -56178,11 +55976,11 @@ ymg
 sLi
 sLi
 sLi
-sLi
-lnn
+tdL
+xDp
 kdr
-ylN
-ylN
+rej
+rej
 kdr
 vTH
 vTH
@@ -56203,12 +56001,12 @@ vTH
 kdK
 mDw
 sdw
-pOn
+kdK
 czi
 jFM
 czi
 pBT
-pOn
+kdK
 vTH
 vTH
 vTH
@@ -56269,7 +56067,7 @@ adg
 adg
 adg
 get
-rXJ
+tVm
 get
 adg
 adg
@@ -56279,7 +56077,7 @@ dot
 adg
 adg
 tVm
-lAV
+get
 get
 adg
 adg
@@ -56364,8 +56162,8 @@ cMa
 czi
 czi
 czi
-icA
-pOn
+cMx
+kdK
 vTH
 vTH
 vTH
@@ -56437,7 +56235,7 @@ adg
 adg
 get
 get
-lAV
+get
 abk
 adg
 adg
@@ -56517,12 +56315,12 @@ vTH
 kdK
 sdw
 sdw
-pOn
+kdK
 czi
 czi
 czi
 pBT
-pOn
+kdK
 vTH
 vTH
 vTH
@@ -56674,12 +56472,12 @@ kdK
 kdK
 sdw
 sdw
-pOn
+kdK
 leP
 czi
 czi
-icA
-pOn
+cMx
+kdK
 vTH
 vTH
 vTH
@@ -56746,7 +56544,7 @@ sHp
 get
 get
 get
-rXJ
+tVm
 tVm
 llJ
 adg
@@ -56836,7 +56634,7 @@ czi
 lUE
 czi
 pBT
-pOn
+kdK
 vTH
 vTH
 vTH
@@ -56988,12 +56786,12 @@ iZa
 sdw
 sdw
 kdK
-pOn
-pOn
-pOn
-pOn
-pOn
-pOn
+kdK
+kdK
+kdK
+kdK
+kdK
+kdK
 vTH
 vTH
 vTH
@@ -64543,15 +64341,15 @@ rcv
 rcv
 rcv
 rcv
-acM
-acM
-acM
-acM
-acM
-acM
-acM
-acM
-acM
+cij
+cij
+cij
+cij
+cij
+cij
+cij
+cij
+cij
 srJ
 srJ
 srJ
@@ -64700,15 +64498,15 @@ rcv
 rcv
 rcv
 rcv
-acM
-uPQ
+cij
+riT
 acN
-wNi
-acM
+tBy
+cij
 lBl
 cyW
-bJz
-acM
+poC
+cij
 srJ
 srJ
 srJ
@@ -64857,15 +64655,15 @@ rcv
 rcv
 rcv
 rOV
-acM
-hEi
+cij
+hZB
 acN
-acM
-acM
-acM
+cij
+cij
+cij
 kzw
-bzF
-acM
+opX
+cij
 srJ
 srJ
 srJ
@@ -65014,15 +64812,15 @@ rcv
 rcv
 rcv
 rOV
-acM
-itz
+cij
+xbr
 acN
-acM
+cij
 acN
-fOW
+xlX
 acN
 acN
-acM
+cij
 srJ
 srJ
 srJ
@@ -65171,15 +64969,15 @@ rcv
 rcv
 rcv
 rOV
-acM
+cij
 uke
 acN
-lzU
+qKM
 acN
-acM
-oIO
+cij
+qMW
 lkN
-acM
+cij
 srJ
 srJ
 srJ
@@ -65328,15 +65126,15 @@ rcv
 rcv
 rcv
 rOV
-acM
-acM
-acM
-acM
+cij
+cij
+cij
+cij
 acN
-acM
-acM
-cqq
-acM
+cij
+cij
+wDU
+cij
 srJ
 srJ
 srJ
@@ -65487,13 +65285,13 @@ rcv
 rcv
 rcv
 rcv
-acM
+cij
 pkp
 acN
 qpJ
-tXZ
-tXZ
-acM
+gbn
+gbn
+cij
 srJ
 srJ
 srJ
@@ -65644,13 +65442,13 @@ rcv
 rcv
 rcv
 rcv
-acM
+cij
 qGr
 acN
 qpJ
-tXZ
-tXZ
-acM
+gbn
+gbn
+cij
 srJ
 srJ
 srJ
@@ -65707,9 +65505,9 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -65801,13 +65599,13 @@ rcv
 rcv
 rcv
 rcv
-acM
-lsY
+cij
+iUV
 acN
 qpJ
-tXZ
-tXZ
-acM
+gbn
+gbn
+cij
 srJ
 srJ
 srJ
@@ -65863,11 +65661,11 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -65958,13 +65756,13 @@ rcv
 rcv
 rcv
 rcv
-acM
+cij
 acN
 acN
 qpJ
-tXZ
-tXZ
-acM
+gbn
+gbn
+cij
 srJ
 srJ
 srJ
@@ -66019,13 +65817,13 @@ rcv
 tQp
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -66085,11 +65883,11 @@ tXZ
 tXZ
 tXZ
 tXZ
-clT
-clT
-clT
-clT
-clT
+dwh
+dwh
+dwh
+dwh
+dwh
 tXZ
 tXZ
 tXZ
@@ -66115,13 +65913,13 @@ tXZ
 tXZ
 tXZ
 tXZ
-acM
+cij
 acN
 gdD
 ady
-tXZ
-tXZ
-acM
+gbn
+gbn
+cij
 srJ
 srJ
 srJ
@@ -66176,13 +65974,13 @@ tQp
 tQp
 rcv
 tXZ
-kDi
-kDi
-kDi
-tXZ
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+ljo
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -66242,11 +66040,11 @@ tXZ
 tXZ
 tXZ
 tXZ
-clT
+dwh
 acG
 wIn
 qzz
-clT
+dwh
 tXZ
 tXZ
 tXZ
@@ -66272,13 +66070,13 @@ tXZ
 tXZ
 tXZ
 tXZ
-acM
+cij
 acN
-kUM
-tXZ
-tXZ
-tXZ
-acM
+iRK
+gbn
+gbn
+gbn
+cij
 srJ
 srJ
 srJ
@@ -66333,23 +66131,23 @@ tQp
 rcv
 rcv
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
 tXZ
 tXZ
-iPW
-iPW
+cij
+cij
 xQQ
-iPW
-iPW
+cij
+cij
 tXZ
 tXZ
 tXZ
@@ -66399,11 +66197,11 @@ tXZ
 tXZ
 tXZ
 tXZ
-clT
+dwh
 sac
-tXZ
+ljo
 jSH
-clT
+dwh
 tXZ
 tXZ
 tXZ
@@ -66428,14 +66226,14 @@ tXZ
 tXZ
 tXZ
 tXZ
-acM
-acM
+cij
+cij
 acN
 acN
-acM
-acM
-acM
-acM
+cij
+cij
+cij
+cij
 rOV
 rOV
 srJ
@@ -66491,23 +66289,23 @@ rcv
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
 tXZ
 tXZ
-iPW
+cij
 cxl
 ftf
 iHC
-acF
-acF
-iPW
+gbn
+gbn
+cij
 tXZ
 tXZ
 tXZ
@@ -66556,11 +66354,11 @@ tXZ
 tXZ
 tXZ
 tXZ
-clT
+dwh
 jxZ
 kFZ
 faZ
-clT
+dwh
 tXZ
 tXZ
 tXZ
@@ -66585,11 +66383,11 @@ tXZ
 tXZ
 tXZ
 tXZ
-acM
-lsY
+cij
+iUV
 acN
 acN
-acM
+cij
 rcv
 rcv
 rcv
@@ -66649,9 +66447,9 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -66662,9 +66460,9 @@ qLR
 mBN
 mBN
 iHC
-acF
-acF
-iPW
+gbn
+gbn
+cij
 tXZ
 tXZ
 tXZ
@@ -66713,11 +66511,11 @@ tXZ
 tXZ
 tXZ
 tXZ
-clT
-clT
-clT
-clT
-clT
+dwh
+dwh
+dwh
+dwh
+dwh
 tXZ
 tXZ
 tXZ
@@ -66742,11 +66540,11 @@ tXZ
 tXZ
 tXZ
 tXZ
-acM
+cij
 acN
 acN
 acN
-acM
+cij
 rcv
 rcv
 rcv
@@ -66806,22 +66604,22 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
 tXZ
 tXZ
 bea
-iPW
+cij
 aeU
 mBN
 iHC
-acF
-acF
-iPW
+gbn
+gbn
+cij
 tXZ
 tXZ
 tXZ
@@ -66899,11 +66697,11 @@ tXZ
 tXZ
 tXZ
 tXZ
-acM
+cij
 pTo
 pTo
-acM
-acM
+cij
+cij
 rcv
 rcv
 fam
@@ -66963,22 +66761,22 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
 tXZ
 tXZ
 bea
-iPW
+cij
 toI
 mBN
 iHC
-acF
-acF
-iPW
+gbn
+gbn
+cij
 tXZ
 tXZ
 auM
@@ -67061,7 +66859,7 @@ tXZ
 tXZ
 tXZ
 tXZ
-gsR
+bzF
 fam
 fam
 tXZ
@@ -67120,22 +66918,22 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
 tXZ
 tXZ
 bea
-iPW
+cij
 aeU
 mBN
 iHC
-acF
-acF
-iPW
+gbn
+gbn
+cij
 tXZ
 tXZ
 tXZ
@@ -67217,8 +67015,8 @@ tXZ
 tXZ
 tXZ
 san
-huO
-gsR
+vUL
+bzF
 fam
 tXZ
 tXZ
@@ -67278,8 +67076,8 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -67290,9 +67088,9 @@ qLR
 cHN
 cHN
 iHC
-acF
-acF
-iPW
+gbn
+gbn
+cij
 tXZ
 tXZ
 tXZ
@@ -67443,13 +67241,13 @@ tXZ
 tXZ
 tXZ
 tXZ
-iPW
-lXU
+cij
+wNB
 cPQ
 iHC
-acF
-acF
-iPW
+gbn
+gbn
+cij
 tXZ
 tXZ
 tXZ
@@ -67601,11 +67399,11 @@ tXZ
 tXZ
 tXZ
 tXZ
-iPW
-iPW
+cij
+cij
 uIf
-iPW
-iPW
+cij
+cij
 tXZ
 tXZ
 tXZ
@@ -68599,7 +68397,7 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
+ljo
 tXZ
 tXZ
 tXZ
@@ -68759,11 +68557,11 @@ tXZ
 sKA
 tXZ
 tXZ
-abV
-abV
+yaE
+yaE
 vTP
-abV
-abV
+yaE
+yaE
 tXZ
 tXZ
 tXZ
@@ -68771,13 +68569,13 @@ tXZ
 tXZ
 tXZ
 tXZ
-awH
+uHt
 jwv
 jwv
 jwv
 jwv
 jwv
-awH
+uHt
 tXZ
 tXZ
 tXZ
@@ -68912,15 +68710,15 @@ tXZ
 tXZ
 tXZ
 tXZ
-abV
+yaE
 iTK
-abV
+yaE
 vTP
-abV
+yaE
 iUi
-rDz
+sPC
 uMK
-abV
+yaE
 tXZ
 tXZ
 tXZ
@@ -68928,13 +68726,13 @@ tXZ
 tXZ
 tXZ
 tXZ
-wFu
-awH
-tXZ
-lLr
-iZM
+tuX
+uHt
+gbn
+aax
+upU
 abX
-wFu
+tuX
 tXZ
 tXZ
 tXZ
@@ -69009,11 +68807,11 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -69069,15 +68867,15 @@ tXZ
 tXZ
 tXZ
 tXZ
-abV
+yaE
 vCU
 acs
 acs
 wJw
-rDz
+sPC
 oDN
-rDz
-abV
+sPC
+yaE
 tXZ
 tXZ
 tXZ
@@ -69085,13 +68883,13 @@ tXZ
 tXZ
 tXZ
 tXZ
-wFu
+tuX
 vOB
 sgU
 sgU
 uEx
 abX
-wFu
+tuX
 tXZ
 tXZ
 tXZ
@@ -69165,13 +68963,13 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -69224,17 +69022,17 @@ tXZ
 tXZ
 tXZ
 tXZ
-abV
-abV
-abV
+yaE
+yaE
+yaE
 dHi
 acs
 acs
 acs
-rDz
+sPC
 xCz
-rDz
-abV
+sPC
+yaE
 tXZ
 tXZ
 tXZ
@@ -69242,13 +69040,13 @@ tXZ
 tXZ
 tXZ
 tXZ
-wFu
-ayZ
+tuX
+tsy
 abX
 abX
 vFM
 fQL
-wFu
+tuX
 tXZ
 tXZ
 tXZ
@@ -69322,13 +69120,13 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -69381,17 +69179,17 @@ tXZ
 tXZ
 tXZ
 tXZ
-abV
+yaE
 xRc
 wJw
 lhk
 acs
 acs
 acs
-rDz
+sPC
 acw
-rDz
-abV
+sPC
+yaE
 tXZ
 tXZ
 tXZ
@@ -69399,13 +69197,13 @@ tXZ
 tXZ
 tXZ
 tXZ
-wFu
+tuX
 vFM
 vFM
 abX
 tdf
 pUu
-wFu
+tuX
 tXZ
 tXZ
 tXZ
@@ -69479,13 +69277,13 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -69538,7 +69336,7 @@ tXZ
 tXZ
 tXZ
 tXZ
-abV
+yaE
 ptX
 wQC
 lhk
@@ -69546,9 +69344,9 @@ acs
 jII
 xRc
 khd
-abV
+yaE
 adS
-abV
+yaE
 tXZ
 tXZ
 tXZ
@@ -69556,13 +69354,13 @@ tXZ
 tXZ
 tXZ
 tXZ
-wFu
+tuX
 vFM
 vFM
 abX
-awH
+uHt
 jwv
-awH
+uHt
 lRY
 tXZ
 tXZ
@@ -69636,13 +69434,13 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -69695,17 +69493,17 @@ tXZ
 tXZ
 tXZ
 tXZ
-abV
-abV
-abV
-abV
-abV
-abV
-abV
-abV
-abV
-abV
-abV
+yaE
+yaE
+yaE
+yaE
+yaE
+yaE
+yaE
+yaE
+yaE
+yaE
+yaE
 tXZ
 tXZ
 tXZ
@@ -69713,7 +69511,7 @@ tXZ
 tXZ
 tXZ
 tXZ
-wFu
+tuX
 hGr
 ugF
 nws
@@ -69737,8 +69535,8 @@ ddJ
 ddJ
 ddJ
 san
-tXZ
-tXZ
+ljo
+ljo
 san
 tXZ
 tXZ
@@ -69793,13 +69591,13 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -69854,15 +69652,15 @@ tXZ
 tXZ
 tXZ
 tXZ
-abV
+yaE
 acx
 acC
-bRO
-acK
-bRO
-abV
+acN
+aam
+acN
+yaE
 acQ
-abV
+yaE
 tXZ
 tXZ
 tXZ
@@ -69870,11 +69668,11 @@ tXZ
 tXZ
 tXZ
 tXZ
-awH
+uHt
 hTt
 hTt
 jwv
-awH
+uHt
 oIz
 dmJ
 eTz
@@ -69893,10 +69691,10 @@ qCP
 hGT
 mUR
 fHK
-tXZ
-tXZ
-tXZ
-tXZ
+ljo
+ljo
+ljo
+ljo
 tXZ
 tXZ
 "}
@@ -69950,13 +69748,13 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -70011,15 +69809,15 @@ tXZ
 tXZ
 tXZ
 tXZ
-abV
-rjg
+yaE
+pRS
 acD
-bRO
-bRO
-bRO
-abV
+acN
+acN
+acN
+yaE
 acs
-abV
+yaE
 tXZ
 tXZ
 tXZ
@@ -70044,16 +69842,16 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
+ljo
+ljo
 lxn
 fXd
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-huO
+ljo
+ljo
+ljo
+ljo
+ljo
+vUL
 tXZ
 tXZ
 "}
@@ -70107,13 +69905,13 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -70123,12 +69921,12 @@ tXZ
 tXZ
 tXZ
 bea
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -70168,15 +69966,15 @@ tXZ
 tXZ
 tXZ
 tXZ
-abV
-bRO
-bRO
-bRO
-abV
-abV
-abV
+yaE
+acN
+acN
+acN
+yaE
+yaE
+yaE
 vCU
-abV
+yaE
 tXZ
 tXZ
 tXZ
@@ -70201,16 +69999,16 @@ tXZ
 tXZ
 tXZ
 tXZ
-huO
-huO
-huO
-huO
-huO
-huO
-huO
-huO
-huO
-huO
+vUL
+vUL
+vUL
+vUL
+vUL
+vUL
+vUL
+vUL
+vUL
+vUL
 tXZ
 tXZ
 "}
@@ -70264,13 +70062,13 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -70280,12 +70078,12 @@ tXZ
 tXZ
 tXZ
 bea
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -70325,15 +70123,15 @@ tXZ
 tXZ
 tXZ
 tXZ
-abV
+yaE
 acz
 acE
 acI
-abV
+yaE
 wJw
 acs
 acs
-abV
+yaE
 tXZ
 tXZ
 tXZ
@@ -70360,11 +70158,11 @@ tXZ
 tXZ
 tXZ
 tXZ
-awH
+uHt
 oHl
-awH
+uHt
 oHl
-awH
+uHt
 tXZ
 tXZ
 tXZ
@@ -70422,11 +70220,11 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -70437,12 +70235,12 @@ tXZ
 tXZ
 tXZ
 bea
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -70466,8 +70264,8 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -70482,15 +70280,15 @@ tXZ
 tXZ
 tXZ
 tXZ
-abV
+yaE
 acA
-acF
+gbn
 acJ
-acL
+ooG
 acs
 acP
 acs
-abV
+yaE
 tXZ
 tXZ
 tXZ
@@ -70519,7 +70317,7 @@ odq
 avx
 oHl
 sji
-avx
+abV
 sse
 eHZ
 tXZ
@@ -70594,23 +70392,23 @@ tXZ
 tXZ
 tXZ
 bea
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
 tXZ
 tXZ
 tXZ
-aat
+ccX
 lRw
 adc
 lRw
-aat
+ccX
 tXZ
 tXZ
 tXZ
@@ -70623,8 +70421,8 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -70639,15 +70437,15 @@ tXZ
 tXZ
 tXZ
 tXZ
-abV
-acB
+yaE
+iUV
 tBr
-bRO
-abV
+acN
+yaE
 acu
-abV
+yaE
 acu
-abV
+yaE
 tXZ
 tXZ
 tXZ
@@ -70673,11 +70471,11 @@ tXZ
 tXZ
 tXZ
 nqu
-clT
+dwh
 kqp
-clT
-clT
-clT
+mDW
+mDW
+mDW
 eHZ
 tXZ
 tXZ
@@ -70744,19 +70542,19 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 bea
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -70765,7 +70563,7 @@ tXZ
 tXZ
 lRw
 acX
-mRr
+fzp
 adj
 lRw
 tXZ
@@ -70780,8 +70578,8 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -70796,11 +70594,11 @@ tXZ
 tXZ
 tXZ
 tXZ
-abV
+yaE
 acu
-abV
+yaE
 acu
-abV
+yaE
 tXZ
 tXZ
 tXZ
@@ -70830,12 +70628,12 @@ tXZ
 tXZ
 tXZ
 nqu
-clT
-awH
+dwh
+uHt
 lJv
-clT
-clT
-awH
+mDW
+mDW
+uHt
 tXZ
 tXZ
 tXZ
@@ -70901,11 +70699,11 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 ujo
@@ -70921,13 +70719,13 @@ tXZ
 tXZ
 tXZ
 lRw
-mRr
+fzp
 adh
-acF
+gbn
 lRw
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -70937,8 +70735,8 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -70953,10 +70751,10 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -70987,11 +70785,11 @@ tXZ
 tXZ
 tXZ
 nqu
-clT
+dwh
 oHl
-clT
-clT
-clT
+mDW
+mDW
+mDW
 eHZ
 tXZ
 tXZ
@@ -71058,11 +70856,11 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
 iFe
-kDi
+qhe
 tXZ
 tXZ
 tXZ
@@ -71071,20 +70869,20 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
+ljo
+qhe
+qhe
+qhe
+qhe
+qhe
 lRw
-mRr
+fzp
 adh
-giU
+ade
 lRw
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -71094,8 +70892,8 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -71110,10 +70908,10 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -71144,11 +70942,11 @@ tXZ
 tXZ
 tXZ
 nqu
-clT
+dwh
 oHl
 cWJ
 lGa
-clT
+mDW
 eHZ
 tXZ
 tXZ
@@ -71215,11 +71013,11 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -71228,20 +71026,20 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
+ljo
+qhe
+qhe
+qhe
+qhe
+qhe
 lRw
-mRr
-mRr
-mRr
+fzp
+fzp
+fzp
 lRw
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -71251,8 +71049,8 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -71302,11 +71100,11 @@ wBj
 wBj
 atx
 onb
-awH
+uHt
 rDO
-awH
+uHt
 rDO
-awH
+uHt
 tXZ
 tXZ
 tXZ
@@ -71327,6 +71125,11 @@ rcv
 tXZ
 tXZ
 iyx
+ljo
+ljo
+ljo
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -71367,17 +71170,11 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-tXZ
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -71386,19 +71183,20 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
+ljo
+qhe
+qhe
+qhe
+qhe
+qhe
 lRw
 adf
 adi
 adl
 lRw
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -71408,8 +71206,8 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -71484,6 +71282,11 @@ rcv
 tXZ
 tXZ
 iyx
+ljo
+ljo
+ljo
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -71537,28 +71340,23 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-kDi
-kDi
-xDp
-xDp
-xDp
-aat
+ljo
+qhe
+qhe
+yaE
+yaE
+yaE
+ccX
 lRw
-cHF
+wSF
 lRw
-aat
-xDp
-xDp
-xDp
-xDp
-xDp
-xDp
+ccX
+yaE
+yaE
+yaE
+yaE
+yaE
+yaE
 wiv
 avx
 iAU
@@ -71607,13 +71405,13 @@ tXZ
 tXZ
 tXZ
 tXZ
-awH
+uHt
 bDN
 bDN
-awH
+uHt
 oHl
 oHl
-awH
+uHt
 tXZ
 wBj
 wBj
@@ -71641,11 +71439,11 @@ tXZ
 tXZ
 tXZ
 iyx
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
+ljo
+ljo
+ljo
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -71701,7 +71499,7 @@ tXZ
 tXZ
 tXZ
 lLr
-sPC
+iSL
 sPC
 sPC
 hxJ
@@ -71716,7 +71514,7 @@ sPC
 sPC
 sPC
 sPC
-sPC
+iSL
 oNT
 tXZ
 tXZ
@@ -71767,9 +71565,9 @@ tXZ
 oHl
 lGa
 wgQ
-tXZ
-tXZ
-tXZ
+gbn
+gbn
+gbn
 oHl
 tXZ
 wBj
@@ -71798,11 +71596,11 @@ tXZ
 tXZ
 tXZ
 iyx
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
+ljo
+ljo
+ljo
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -71858,6 +71656,7 @@ tXZ
 tXZ
 tXZ
 lLr
+iSL
 sPC
 sPC
 sPC
@@ -71872,8 +71671,7 @@ sPC
 sPC
 sPC
 sPC
-sPC
-sPC
+iSL
 oNT
 tXZ
 tXZ
@@ -71921,13 +71719,13 @@ tXZ
 tXZ
 tXZ
 tXZ
-awH
+uHt
 fwh
 wgQ
-tXZ
-tXZ
-tXZ
-wFu
+gbn
+gbn
+gbn
+tuX
 tXZ
 tXZ
 tXZ
@@ -71955,11 +71753,11 @@ tXZ
 tXZ
 tXZ
 iyx
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
+ljo
+ljo
+ljo
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -72016,7 +71814,7 @@ tXZ
 tXZ
 tXZ
 bPG
-xDp
+yaE
 sPC
 sPC
 sPC
@@ -72029,7 +71827,7 @@ sPC
 sPC
 sPC
 tkh
-xDp
+yaE
 gpi
 bPG
 kLI
@@ -72079,11 +71877,11 @@ tXZ
 tXZ
 tXZ
 mSv
-clT
+mDW
 wgQ
-tXZ
-tXZ
-tXZ
+gbn
+gbn
+gbn
 oHl
 tXZ
 tXZ
@@ -72112,6 +71910,11 @@ tXZ
 tXZ
 tXZ
 iyx
+ljo
+ljo
+ljo
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -72144,18 +71947,13 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-awH
+uHt
 jwv
 hTt
 cXd
 hTt
 jwv
-awH
+uHt
 tXZ
 tXZ
 tXZ
@@ -72208,12 +72006,12 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -72236,11 +72034,11 @@ tXZ
 tXZ
 tXZ
 mSv
-clT
-clT
-awH
-tXZ
-tXZ
+mDW
+mDW
+uHt
+gbn
+gbn
 oHl
 tXZ
 tXZ
@@ -72269,6 +72067,10 @@ tXZ
 tXZ
 san
 wlO
+ljo
+ljo
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -72302,32 +72104,28 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-wFu
-iZM
+tuX
+upU
 abX
 abX
 prh
-awH
-wFu
+uHt
+tuX
 tXZ
 tXZ
-abV
-abV
-abV
-abV
-abV
-abV
-abV
+yaE
+yaE
+yaE
+yaE
+yaE
+yaE
+yaE
 dMQ
 dMQ
-abV
-abV
-abV
-kDi
+yaE
+yaE
+yaE
+qhe
 tXZ
 tXZ
 haj
@@ -72356,21 +72154,21 @@ tXZ
 tXZ
 tXZ
 tXZ
-wni
-wni
-aax
-wni
-wni
-aax
-wni
-wni
-wni
-wni
-wni
-aax
-wni
-wni
-kDi
+ccX
+ccX
+dMQ
+ccX
+ccX
+dMQ
+ccX
+ccX
+ccX
+ccX
+ccX
+dMQ
+ccX
+ccX
+qhe
 tXZ
 tXZ
 tXZ
@@ -72392,13 +72190,13 @@ mRc
 mRc
 bzt
 tXZ
-awH
+uHt
 mcW
-clT
+mDW
 jiS
-tXZ
-tXZ
-wFu
+gbn
+gbn
+tuX
 tXZ
 tXZ
 tXZ
@@ -72468,23 +72266,23 @@ vmq
 dkR
 abX
 gdR
+gbn
+tuX
 tXZ
-wFu
 tXZ
-tXZ
-abV
+yaE
 qTt
 tcq
-rPp
-abV
-bRO
-bRO
-bRO
-bRO
+qGr
+yaE
+acN
+acN
+acN
+acN
 jLM
-acF
-abV
-kDi
+gbn
+yaE
+qhe
 tXZ
 tXZ
 ygR
@@ -72513,21 +72311,21 @@ tXZ
 tXZ
 tXZ
 tXZ
-wni
+ccX
 aaL
 acN
 acN
 aaP
 acN
 acN
-wni
+ccX
 aaT
 acN
 acN
 acN
 acN
-wni
-kDi
+ccX
+qhe
 tXZ
 tXZ
 tXZ
@@ -72544,17 +72342,17 @@ tXZ
 tXZ
 tXZ
 pQS
-wni
+cUB
 aJP
-wni
-wni
+cUB
+cUB
 wtK
 oHl
 sON
 uJZ
 pCg
-tXZ
-tXZ
+gbn
+gbn
 oHl
 tXZ
 tXZ
@@ -72582,8 +72380,8 @@ yjc
 ent
 ent
 sXy
-hoU
-ent
+ada
+puh
 tXZ
 tXZ
 tXZ
@@ -72626,22 +72424,22 @@ vFM
 abX
 gdR
 bXh
-wFu
+tuX
 tXZ
 tXZ
-moC
-bRO
-bRO
+abj
+acN
+acN
 krb
 jCB
-bRO
-bRO
-bRO
-bRO
+acN
+acN
+acN
+acN
 oPb
 dDx
-abV
-kDi
+yaE
+qhe
 tXZ
 tXZ
 tjx
@@ -72673,18 +72471,18 @@ tXZ
 ahG
 gpZ
 acN
-aaN
-aaN
+lpE
+lpE
 acN
 acN
-wni
-tXZ
+ccX
+gbn
 acN
 acN
 aaQ
 acN
-wni
-kDi
+ccX
+qhe
 tXZ
 tXZ
 tXZ
@@ -72701,18 +72499,18 @@ tXZ
 tXZ
 tXZ
 wDm
-wni
-cHj
+cUB
+lXU
 ylP
-wni
-acN
-awH
-san
-san
-awH
-san
-san
-awH
+cUB
+dFC
+uHt
+oLW
+oLW
+uHt
+oLW
+oLW
+uHt
 tXZ
 tXZ
 tXZ
@@ -72739,8 +72537,8 @@ ent
 ent
 rcv
 san
-hoU
-hoU
+ada
+ada
 tXZ
 tXZ
 tXZ
@@ -72777,28 +72575,28 @@ tXZ
 tXZ
 tXZ
 tXZ
-wFu
+tuX
 fwl
 abX
 abX
 bve
 abX
-wFu
+tuX
 tXZ
 tXZ
-abV
-abV
-abV
-abV
-abV
-acB
-bRO
+yaE
+yaE
+yaE
+yaE
+yaE
+iUV
+acN
 lpE
 lpE
-bRO
-bRO
+acN
+acN
 huD
-kDi
+qhe
 tXZ
 tXZ
 tjx
@@ -72827,23 +72625,23 @@ tXZ
 tXZ
 tXZ
 tXZ
-wni
+ccX
 aaA
 acN
 qGr
 qGr
-aaR
+paF
 acN
-wni
-wni
-wni
-wni
+ccX
+ccX
+ccX
+ccX
 acN
 acN
-wni
-wni
-wni
-wni
+ccX
+ccX
+ccX
+ccX
 tXZ
 tXZ
 tXZ
@@ -72860,7 +72658,7 @@ tXZ
 wDm
 aJP
 kIk
-acN
+dFC
 aJP
 uVk
 tXZ
@@ -72896,8 +72694,8 @@ ent
 rcv
 rcv
 rcv
-hoU
-hoU
+ada
+ada
 tXZ
 tXZ
 tXZ
@@ -72934,28 +72732,28 @@ tXZ
 tXZ
 tXZ
 tXZ
-awH
+uHt
 jwv
 mUN
 jwv
-awH
+uHt
 jwv
-awH
+uHt
 tXZ
 tXZ
-abV
+yaE
 qTt
 tcq
-rPp
-abV
-bRO
-bRO
-rPp
-rPp
+qGr
+yaE
+acN
+acN
+qGr
+qGr
 paF
-bRO
+acN
 huD
-kDi
+qhe
 tXZ
 tXZ
 tjx
@@ -72984,12 +72782,12 @@ tXZ
 tXZ
 tXZ
 tXZ
-wni
+ccX
 aaA
 acN
 qGr
 qGr
-aaR
+paF
 acN
 aaS
 acN
@@ -73000,7 +72798,7 @@ acN
 acN
 qGr
 aaX
-wni
+ccX
 tXZ
 tXZ
 tXZ
@@ -73016,7 +72814,7 @@ tXZ
 tXZ
 rFP
 dzr
-acN
+dFC
 ccD
 dzr
 iCi
@@ -73053,8 +72851,8 @@ rcv
 rOV
 rOV
 rcv
-hoU
-hoU
+ada
+ada
 tXZ
 tXZ
 tXZ
@@ -73091,28 +72889,28 @@ tXZ
 tXZ
 tXZ
 tXZ
-wFu
+tuX
 ugF
 abX
-rJG
-wFu
+nqL
+tuX
 tXZ
 tXZ
 tXZ
 tXZ
-moC
-bRO
-bRO
+abj
+acN
+acN
 krb
 jCB
-bRO
+acN
 lsd
-rPp
-rPp
-bRO
-bRO
-abV
-kDi
+qGr
+qGr
+acN
+acN
+yaE
+qhe
 tXZ
 tXZ
 ygR
@@ -73144,20 +72942,20 @@ tXZ
 ahG
 qGr
 acN
-aaO
-aaO
+vIk
+vIk
 acN
 acN
-wni
-acN
-acN
-acN
+ccX
 acN
 acN
 acN
 acN
 acN
-wni
+acN
+acN
+acN
+ccX
 tXZ
 tXZ
 tXZ
@@ -73172,10 +72970,10 @@ tXZ
 tXZ
 tXZ
 tXZ
-wni
+cUB
 aJP
-wni
-wni
+cUB
+cUB
 tXZ
 tXZ
 tXZ
@@ -73210,8 +73008,8 @@ rcv
 rOV
 rOV
 rcv
-hoU
-hoU
+ada
+ada
 tXZ
 tXZ
 tXZ
@@ -73248,28 +73046,28 @@ tXZ
 tXZ
 tXZ
 tXZ
-wFu
+tuX
 kiv
 nws
-vSd
-wFu
+gYv
+tuX
 tXZ
 tXZ
 tXZ
 tXZ
-abV
-abV
-abV
-abV
-abV
-acB
-bRO
+yaE
+yaE
+yaE
+yaE
+yaE
+iUV
+acN
 vIk
 vIk
-bRO
+acN
 skw
-abV
-kDi
+yaE
+qhe
 tXZ
 tXZ
 haj
@@ -73298,14 +73096,14 @@ tXZ
 tXZ
 tXZ
 tXZ
-wni
+ccX
 aaL
 acN
 acN
 aaQ
 acN
 acN
-wni
+ccX
 acN
 acN
 acN
@@ -73314,7 +73112,7 @@ acN
 acN
 acN
 acN
-wni
+ccX
 tXZ
 tXZ
 tXZ
@@ -73366,9 +73164,9 @@ rcv
 rOV
 rOV
 rcv
-hoU
-hoU
-hoU
+ada
+ada
+ada
 tXZ
 tXZ
 tXZ
@@ -73405,28 +73203,28 @@ tXZ
 tXZ
 tXZ
 tXZ
-awH
+uHt
 jwv
 jwv
 jwv
-awH
+uHt
 tXZ
 tXZ
 tXZ
 tXZ
-abV
+yaE
 qTt
 tcq
-rPp
-abV
-bRO
-bRO
-bRO
-bRO
+qGr
+yaE
+acN
+acN
+acN
+acN
 vuV
 qjZ
-abV
-kDi
+yaE
+qhe
 tXZ
 tXZ
 haj
@@ -73455,23 +73253,23 @@ tXZ
 tXZ
 tXZ
 tXZ
-wni
-wni
-cqq
-wni
-wni
-cqq
-wni
-wni
-wni
-wni
+ccX
+ccX
+wDU
+ccX
+ccX
+wDU
+ccX
+ccX
+ccX
+ccX
 acN
 acN
-aaN
+lpE
 acN
 acN
 aaY
-wni
+ccX
 tXZ
 tXZ
 tXZ
@@ -73523,9 +73321,9 @@ rOV
 rOV
 rcv
 rcv
-hoU
-hoU
-hoU
+ada
+ada
+ada
 tXZ
 tXZ
 tXZ
@@ -73571,19 +73369,19 @@ tXZ
 tXZ
 tXZ
 tXZ
-moC
-bRO
-bRO
+abj
+acN
+acN
 krb
 jCB
-bRO
-bRO
-bRO
-bRO
+acN
+acN
+acN
+acN
 xIT
 cyd
-abV
-kDi
+yaE
+qhe
 tXZ
 qsC
 kyp
@@ -73612,23 +73410,23 @@ tXZ
 tXZ
 tXZ
 tXZ
+ujo
+ujo
+ujo
+ujo
 tXZ
 tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-wni
+ccX
 myk
 aaW
 qGr
 qGr
-ccD
+krb
 aaZ
-wni
+ccX
 tXZ
 tXZ
 tXZ
@@ -73679,9 +73477,9 @@ rcv
 rOV
 rOV
 rcv
-hoU
-hoU
-hoU
+ada
+ada
+ada
 tXZ
 tXZ
 tXZ
@@ -73700,11 +73498,11 @@ tXZ
 tXZ
 tXZ
 tXZ
-jrE
-jrE
+rRK
+rRK
 dfW
-jrE
-jrE
+rRK
+rRK
 tXZ
 tXZ
 tXZ
@@ -73728,19 +73526,19 @@ tXZ
 tXZ
 tXZ
 tXZ
-abV
-abV
-abV
-abV
-abV
+yaE
+yaE
+yaE
+yaE
+yaE
 wDU
 xeW
 wDU
-abV
-abV
-abV
-abV
-kDi
+yaE
+yaE
+yaE
+yaE
+qhe
 tXZ
 qje
 xIP
@@ -73769,23 +73567,23 @@ tXZ
 tXZ
 tXZ
 tXZ
+ujo
+ujo
+ujo
+ujo
 tXZ
 tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-wni
-wni
-cqq
-wni
-cqq
-wni
-wni
-wni
+ccX
+ccX
+wDU
+ccX
+wDU
+ccX
+ccX
+ccX
 tXZ
 tXZ
 tXZ
@@ -73836,8 +73634,8 @@ rcv
 rcv
 rcv
 rcv
-ent
-ent
+puh
+puh
 tXZ
 tXZ
 tXZ
@@ -73856,13 +73654,13 @@ tXZ
 tXZ
 tXZ
 tXZ
-jrE
-jrE
+rRK
+rRK
 lZm
-uMb
+mye
 fFd
-jrE
-jrE
+rRK
+rRK
 tXZ
 tXZ
 tXZ
@@ -73926,10 +73724,10 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
-tXZ
-tXZ
+ujo
+ujo
+ujo
+ujo
 tXZ
 tXZ
 tXZ
@@ -73992,8 +73790,8 @@ bSn
 rcv
 rcv
 san
-ent
-ent
+puh
+puh
 tXZ
 tXZ
 tXZ
@@ -74012,15 +73810,15 @@ tXZ
 tXZ
 tXZ
 tXZ
-jrE
-jrE
-rJC
-rJC
-rJC
-rJC
-rJC
-jrE
-jrE
+rRK
+rRK
+hHC
+hHC
+hHC
+hHC
+hHC
+rRK
+rRK
 tXZ
 tXZ
 tXZ
@@ -74083,10 +73881,10 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
-tXZ
-tXZ
+ujo
+ujo
+ujo
+ujo
 tXZ
 tXZ
 tXZ
@@ -74149,8 +73947,8 @@ ent
 ent
 ent
 sXy
-ent
-ent
+puh
+puh
 tXZ
 tXZ
 tXZ
@@ -74168,18 +73966,18 @@ tXZ
 tXZ
 tXZ
 tXZ
-jrE
-jrE
-qXZ
-rJC
+rRK
+rRK
+leI
+hHC
 fxH
 sVY
 kiW
-rJC
+hHC
 uWv
-jrE
-jrE
-jrE
+rRK
+rRK
+rRK
 tXZ
 tXZ
 tXZ
@@ -74251,15 +74049,15 @@ tXZ
 tXZ
 tXZ
 tXZ
-iPW
+cij
 dMQ
-iPW
-iPW
-iPW
-iPW
-iPW
-iPW
-iPW
+cij
+cij
+cij
+cij
+cij
+cij
+cij
 tXZ
 tXZ
 tXZ
@@ -74306,8 +74104,8 @@ ent
 ent
 ent
 sXy
-ent
-ent
+puh
+puh
 tXZ
 tXZ
 tXZ
@@ -74325,19 +74123,19 @@ tXZ
 tXZ
 tXZ
 tXZ
-jrE
-jmN
-rJC
+rRK
+tfo
+hHC
 btJ
-tXZ
-tXZ
-tXZ
+gbn
+gbn
+gbn
 mpl
 tRU
 tRU
 oOQ
-jrE
-pUe
+rRK
+itz
 uXJ
 tXZ
 tXZ
@@ -74408,15 +74206,15 @@ tXZ
 tXZ
 tXZ
 tXZ
-iPW
+cij
 riT
-bRO
+acN
 tBy
-iPW
-gaQ
-pRS
-dxV
-iPW
+cij
+lBl
+cyW
+poC
+cij
 tXZ
 tXZ
 tXZ
@@ -74463,7 +74261,7 @@ ent
 ent
 ent
 sXy
-ent
+puh
 rcv
 tXZ
 tXZ
@@ -74484,15 +74282,15 @@ tXZ
 tXZ
 fjd
 uWv
-rJC
+hHC
 hhU
-tXZ
+gbn
 llL
-tXZ
+gbn
 sxF
-tXZ
-rvZ
-rJC
+gbn
+vJN
+hHC
 twA
 rJC
 tGN
@@ -74565,13 +74363,13 @@ tXZ
 tXZ
 tXZ
 tXZ
-iPW
+cij
 hZB
-bRO
-iPW
-iPW
-iPW
-ach
+acN
+cij
+cij
+cij
+kzw
 opX
 huD
 tXZ
@@ -74639,19 +74437,19 @@ tXZ
 tXZ
 tXZ
 tXZ
-jrE
+rRK
 pqD
-rJC
+hHC
 pUW
-tXZ
-tXZ
-tXZ
+gbn
+gbn
+gbn
 mpl
 doE
 doE
 oOQ
-jrE
-tRU
+rRK
+tVC
 wxC
 fam
 tXZ
@@ -74722,15 +74520,15 @@ tXZ
 tXZ
 tXZ
 tXZ
-moC
+abj
 xbr
-bRO
-iPW
-bRO
-iNO
-bRO
-bRO
-iPW
+acN
+cij
+acN
+xlX
+acN
+acN
+cij
 tXZ
 tXZ
 tXZ
@@ -74796,18 +74594,18 @@ tXZ
 tXZ
 tXZ
 tXZ
-jrE
-jrE
-qXZ
-rJC
+rRK
+rRK
+leI
+hHC
 pUe
 pUe
 pUe
-rJC
-rJC
-jrE
-jrE
-jrE
+hHC
+hHC
+rRK
+rRK
+rRK
 fam
 fam
 fam
@@ -74867,27 +74665,27 @@ tXZ
 tXZ
 tXZ
 tXZ
-wni
-wni
-wni
-wni
-wni
-wni
-wni
-aax
-wni
-wni
-wni
+ccX
+ccX
+ccX
+ccX
+ccX
+ccX
+ccX
+dMQ
+ccX
+ccX
+ccX
 tXZ
-iPW
-tdL
-bRO
-kLj
-bRO
-iPW
+cij
+uke
+acN
+qKM
+acN
+cij
 qMW
-wxW
-iPW
+lkN
+cij
 tXZ
 tXZ
 tXZ
@@ -74954,15 +74752,15 @@ tXZ
 tXZ
 tXZ
 tXZ
-jrE
-jrE
-rJC
-rJC
-rJC
-rJC
+rRK
+rRK
+hHC
+hHC
+hHC
+hHC
 oOQ
-jrE
-jrE
+rRK
+rRK
 tQp
 fam
 fam
@@ -75007,12 +74805,12 @@ tXZ
 tXZ
 tXZ
 tXZ
-aat
+ccX
 rFn
 rFn
-aat
-aat
-aat
+ccX
+ccX
+ccX
 rJC
 rJC
 rJC
@@ -75029,22 +74827,22 @@ acN
 acN
 acN
 acN
-wni
+ccX
 acN
 acN
 acN
 acN
-wni
+ccX
 tXZ
-iPW
-iPW
-iPW
-iPW
-bRO
-iPW
-iPW
-iPW
-iPW
+cij
+cij
+cij
+cij
+acN
+cij
+cij
+cij
+cij
 tXZ
 tXZ
 tXZ
@@ -75112,13 +74910,13 @@ tXZ
 tXZ
 tXZ
 tXZ
-jrE
-jrE
+rRK
+rRK
 sBP
 tEa
 eiW
-jrE
-jrE
+rRK
+rRK
 tQp
 tQp
 fam
@@ -75168,7 +74966,7 @@ rFn
 hHC
 hHC
 abt
-acF
+gbn
 rFn
 rJC
 rJC
@@ -75181,27 +74979,27 @@ tXZ
 tXZ
 tXZ
 tXZ
-wni
-ccD
+ccX
+krb
 gdD
 gdD
 acN
-wni
+ccX
 gog
 acN
 acN
 acN
-wni
+ccX
 tXZ
 tXZ
 tXZ
-iPW
-bRO
-bRO
-toZ
-acF
-acF
-iPW
+cij
+acN
+acN
+qpJ
+gbn
+gbn
+cij
 tXZ
 tXZ
 tXZ
@@ -75270,11 +75068,11 @@ tXZ
 tXZ
 tXZ
 tXZ
-jrE
-jrE
+rRK
+rRK
 gnm
-jrE
-jrE
+rRK
+rRK
 tXZ
 tQp
 fam
@@ -75321,12 +75119,12 @@ tXZ
 tXZ
 tXZ
 tXZ
-aat
+ccX
 hHC
 hHC
 hJj
 hJj
-aat
+ccX
 rJC
 rJC
 rJC
@@ -75338,27 +75136,27 @@ tXZ
 tXZ
 tXZ
 tXZ
-wni
-wni
-tXZ
+ccX
+ccX
+gbn
 gut
 acN
-wni
+ccX
 acN
 acN
 acN
 acN
-wni
+ccX
 tXZ
 tXZ
 tXZ
-moC
+abj
 cUx
-bRO
-toZ
-acF
-acF
-jmO
+acN
+qpJ
+gbn
+gbn
+lwR
 tXZ
 tXZ
 tXZ
@@ -75478,12 +75276,12 @@ tXZ
 tXZ
 tXZ
 tXZ
-aat
+ccX
 gWx
 hHC
 hHC
 hHC
-aat
+ccX
 rJC
 rJC
 rJC
@@ -75495,27 +75293,27 @@ tXZ
 tXZ
 tXZ
 tXZ
-wni
+ccX
 acN
 uSB
 uSB
 acN
-wni
-wni
-wni
+ccX
+ccX
+ccX
 ooG
-wni
-wni
+ccX
+ccX
 tXZ
 tXZ
 tXZ
-iPW
+cij
 oBM
-bRO
-toZ
-acF
-acF
-iPW
+acN
+qpJ
+gbn
+gbn
+cij
 tXZ
 tXZ
 tXZ
@@ -75652,27 +75450,27 @@ tXZ
 tXZ
 tXZ
 tXZ
-wni
+ccX
 acN
 acN
 acN
 acN
-pQw
+jCB
 acN
 aam
 acN
 acN
-wni
+ccX
 tXZ
 tXZ
 tXZ
-moC
-bRO
-bRO
-toZ
-acF
-acF
-iPW
+abj
+acN
+acN
+qpJ
+gbn
+gbn
+cij
 tXZ
 tXZ
 tXZ
@@ -75792,12 +75590,12 @@ tQp
 tQp
 tQp
 tXZ
-aat
+ccX
 rFn
 rFn
-aat
-aat
-aat
+ccX
+ccX
+ccX
 rJC
 rJC
 rJC
@@ -75809,27 +75607,27 @@ tXZ
 tXZ
 tXZ
 tXZ
-wni
-wni
-wni
-wni
+ccX
+ccX
+ccX
+ccX
 jal
-wni
+ccX
 acN
 acN
 acN
 acN
-wni
+ccX
 tXZ
 tXZ
 tXZ
-iPW
-bRO
-nCA
-pad
-acF
-acF
-jmO
+cij
+acN
+gdD
+ady
+gbn
+gbn
+lwR
 tXZ
 tXZ
 tXZ
@@ -75971,22 +75769,22 @@ acN
 acN
 acN
 acN
-wni
+ccX
 acN
 acN
 acN
 acN
-wni
+ccX
 tXZ
 tXZ
 tXZ
-iPW
-bRO
-wrd
-acF
-acF
-acF
-iPW
+cij
+acN
+iRK
+gbn
+gbn
+gbn
+cij
 tXZ
 tXZ
 tXZ
@@ -76123,27 +75921,27 @@ tXZ
 tXZ
 tXZ
 tXZ
-wni
+ccX
 gog
 acN
 acN
 acN
-wni
+ccX
 acN
 acN
 acN
 acN
-wni
+ccX
 tXZ
 tXZ
 tXZ
-iPW
-iPW
+cij
+cij
 wDU
-iPW
-acF
-acF
-iPW
+cij
+gbn
+gbn
+cij
 tXZ
 tXZ
 tXZ
@@ -76280,7 +76078,7 @@ tXZ
 tXZ
 tXZ
 tXZ
-wni
+ccX
 lkN
 acN
 qGr
@@ -76290,17 +76088,17 @@ aaV
 acN
 lkN
 aaW
-wni
+ccX
 tXZ
 tXZ
 tXZ
 ujo
 ujo
 ujo
-iPW
-iPW
-iPW
-iPW
+cij
+cij
+cij
+cij
 tXZ
 tXZ
 tXZ
@@ -76437,17 +76235,17 @@ tXZ
 tXZ
 tXZ
 tXZ
-wni
-wni
-cqq
-wni
-wni
-wni
-wni
-cqq
-wni
-wni
-wni
+ccX
+ccX
+wDU
+ccX
+ccX
+ccX
+ccX
+wDU
+ccX
+ccX
+ccX
 tXZ
 tXZ
 tXZ
@@ -90525,9 +90323,9 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
-tXZ
+ljo
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -90684,8 +90482,8 @@ tXZ
 bea
 bea
 fLF
-kDi
-kDi
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -90841,9 +90639,9 @@ bea
 bea
 bea
 fLF
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -90993,14 +90791,14 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
+ljo
 bea
 bea
 bea
 fLF
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -91150,14 +90948,14 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
+ljo
 bea
 bea
 bea
 fLF
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -91307,14 +91105,14 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
+ljo
 bea
 bea
 bea
-acN
-kDi
-kDi
-kDi
+bGi
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -91464,14 +91262,14 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
+ljo
 bea
 bea
 bea
 ujo
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -91621,14 +91419,14 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
+ljo
 bea
 bea
 bea
 ujo
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -91783,9 +91581,9 @@ bea
 bea
 bea
 ujo
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -91940,8 +91738,8 @@ tXZ
 bea
 bea
 ujo
-kDi
-kDi
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -92095,9 +91893,9 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
-tXZ
+ljo
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -93095,11 +92893,11 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -93107,13 +92905,13 @@ tXZ
 tXZ
 tXZ
 tXZ
-abW
-abW
-abW
-abW
-abW
-abW
-abW
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
 tXZ
 tXZ
 tXZ
@@ -93248,15 +93046,15 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -93264,13 +93062,13 @@ tXZ
 tXZ
 tXZ
 tXZ
-abW
-abW
-abW
-abW
-abW
-abW
-abW
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
 tXZ
 tXZ
 tXZ
@@ -93405,15 +93203,15 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -93421,13 +93219,13 @@ tXZ
 tXZ
 tXZ
 tXZ
-abW
-abW
-abW
-abW
-abW
-abW
-abW
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
 tXZ
 tXZ
 tXZ
@@ -93560,17 +93358,17 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -93578,13 +93376,13 @@ tXZ
 tXZ
 tXZ
 tXZ
-abW
-abW
-abW
-abW
-abW
-abW
-abW
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
 tXZ
 tXZ
 tXZ
@@ -93717,17 +93515,17 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -93735,13 +93533,13 @@ tXZ
 tXZ
 tXZ
 tXZ
-abW
-abW
-abW
-abW
-abW
-abW
-abW
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
 tXZ
 tXZ
 tXZ
@@ -93874,17 +93672,17 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -93892,13 +93690,13 @@ tXZ
 tXZ
 tXZ
 tXZ
-abW
-abW
-abW
-abW
-abW
-abW
-abW
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
 tXZ
 tXZ
 tXZ
@@ -94031,17 +93829,17 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -94049,13 +93847,13 @@ tXZ
 tXZ
 tXZ
 tXZ
-abW
-abW
-abW
-abW
-abW
-tXZ
-tXZ
+ktr
+ktr
+ktr
+ktr
+ktr
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -94190,15 +93988,15 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -94206,13 +94004,13 @@ tXZ
 tXZ
 tXZ
 tXZ
-abW
-abW
-abW
-abW
-abW
-tXZ
-tXZ
+ktr
+ktr
+ktr
+ktr
+ktr
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -94347,15 +94145,15 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -94389,7 +94187,7 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
+ljo
 tXZ
 tXZ
 "}
@@ -94504,15 +94302,15 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -94537,16 +94335,16 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
+ljo
+ljo
+ljo
+ljo
+ljo
+ljo
+ljo
+ljo
+ljo
+ljo
 tXZ
 tXZ
 "}
@@ -94661,15 +94459,15 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -94818,15 +94616,15 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -94942,11 +94740,11 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -94975,15 +94773,15 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -95009,7 +94807,7 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
+ljo
 wBj
 wBj
 wBj
@@ -95099,11 +94897,11 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -95132,11 +94930,11 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -95166,7 +94964,7 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
+ljo
 wBj
 wBj
 wBj
@@ -95256,11 +95054,43 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+ljo
+ljo
+ljo
+tXZ
+tXZ
+tXZ
+tXZ
+tXZ
+tXZ
+tXZ
+tXZ
+tXZ
+tXZ
+tXZ
+tXZ
+tXZ
+tXZ
+tXZ
+tXZ
+tXZ
+tXZ
+tXZ
+tXZ
+tXZ
+tXZ
+tXZ
+tXZ
+tXZ
+ljo
+ljo
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -95291,39 +95121,7 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
+ljo
 wBj
 wBj
 wBj
@@ -95407,17 +95205,26 @@ tXZ
 tXZ
 tXZ
 tXZ
+ljo
+ljo
+ljo
+ljo
+ljo
+ljo
+qhe
+qhe
+qhe
+qhe
+qhe
+ljo
+ljo
+ljo
 tXZ
 tXZ
 tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
 tXZ
 tXZ
 tXZ
@@ -95437,6 +95244,10 @@ tXZ
 tXZ
 tXZ
 tXZ
+ljo
+ljo
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -95467,20 +95278,7 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
+ljo
 wBj
 wBj
 wBj
@@ -95564,17 +95362,26 @@ tXZ
 tXZ
 tXZ
 tXZ
+ljo
+ljo
+ljo
+ljo
+ljo
+ljo
+qhe
+qhe
+qhe
+qhe
+qhe
+ljo
+ljo
+ljo
 tXZ
 tXZ
 tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
 tXZ
 tXZ
 tXZ
@@ -95620,24 +95427,15 @@ tXZ
 tXZ
 tXZ
 tXZ
+ljo
+ljo
+ljo
+ljo
+ljo
+ljo
+ljo
 tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
+ljo
 wBj
 wBj
 wBj
@@ -95721,17 +95519,26 @@ tXZ
 tXZ
 tXZ
 tXZ
+ljo
+ljo
+ljo
+ljo
+ljo
+ljo
+qhe
+qhe
+qhe
+qhe
+qhe
+ljo
+ljo
+ljo
 tXZ
 tXZ
 tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
 tXZ
 tXZ
 tXZ
@@ -95777,29 +95584,20 @@ tXZ
 tXZ
 tXZ
 tXZ
+ljo
+ljo
+ljo
+ljo
+ljo
+ljo
+ljo
 tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
+ljo
+ljo
+ljo
+ljo
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -95878,23 +95676,23 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
-tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+ljo
+ljo
+ljo
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -95951,12 +95749,12 @@ wBj
 wBj
 wBj
 tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
+ljo
+ljo
+ljo
+ljo
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -96036,24 +95834,24 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-tXZ
-tXZ
+ljo
+ljo
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -96108,12 +95906,12 @@ wBj
 wBj
 wBj
 tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
+ljo
+ljo
+ljo
+ljo
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -96193,24 +95991,24 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-tXZ
-tXZ
+ljo
+ljo
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -96352,15 +96150,15 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 skH
 gkU
 skH
@@ -96509,15 +96307,15 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 skH
 gyV
 jBC
@@ -96544,12 +96342,12 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
+ljo
+ljo
+ljo
+ljo
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -96651,30 +96449,30 @@ abW
 abW
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+ljo
 tXZ
 tXZ
-tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 skH
 eWi
 mFL
@@ -96692,21 +96490,21 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-tXZ
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+ljo
 tXZ
 tXZ
 tXZ
@@ -96808,30 +96606,30 @@ abW
 abW
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+ljo
 tXZ
 tXZ
-tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 wQq
 kul
 mke
@@ -96849,21 +96647,21 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-tXZ
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+ljo
 tXZ
 tXZ
 tXZ
@@ -96880,7 +96678,7 @@ tXZ
 tXZ
 tXZ
 dhZ
-fsE
+rDz
 vIa
 uQh
 btj
@@ -96965,30 +96763,30 @@ abW
 abW
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+ljo
 tXZ
 tXZ
-tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 skH
 sHT
 mke
@@ -97006,21 +96804,21 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-tXZ
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+ljo
 tXZ
 tXZ
 tXZ
@@ -97037,7 +96835,7 @@ tXZ
 tXZ
 tXZ
 lIw
-fsE
+rDz
 vIa
 mGP
 btj
@@ -97122,30 +96920,30 @@ abW
 abW
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+ljo
 tXZ
 tXZ
-tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 skH
 aVf
 mke
@@ -97163,23 +96961,23 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -97194,10 +96992,10 @@ tXZ
 tXZ
 tXZ
 sii
-fsE
-fsE
+rDz
+rDz
 vqT
-fsE
+rDz
 igr
 tXZ
 tXZ
@@ -97279,30 +97077,30 @@ abW
 abW
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+ljo
 tXZ
 tXZ
-tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 skH
 gkU
 dWh
@@ -97320,23 +97118,23 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -97351,10 +97149,10 @@ tXZ
 tXZ
 tXZ
 phC
-fsE
-fsE
-fsE
-fsE
+rDz
+rDz
+rDz
+rDz
 nFu
 tXZ
 tXZ
@@ -97436,29 +97234,29 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+ljo
 tXZ
 tXZ
-tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 skH
 skH
 rsd
@@ -97477,23 +97275,23 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -97593,29 +97391,29 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+ljo
 tXZ
 tXZ
-tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 wQq
 otC
 smO
@@ -97634,23 +97432,23 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -97750,29 +97548,29 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+ljo
 tXZ
 tXZ
-tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 skH
 skH
 qeh
@@ -97791,23 +97589,23 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -97907,30 +97705,30 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+ljo
 tXZ
-tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 skH
 gkU
 skH
@@ -97948,23 +97746,23 @@ tXZ
 tXZ
 tXZ
 tXZ
+ljo
+ljo
+ljo
+ljo
 tXZ
 tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -98036,11 +97834,11 @@ tXZ
 tXZ
 tXZ
 tXZ
-abW
-abW
-abW
-abW
-abW
+ktr
+ktr
+ktr
+ktr
+ktr
 tXZ
 tXZ
 tXZ
@@ -98064,38 +97862,35 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+ljo
 tXZ
-tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-tXZ
-tXZ
-tXZ
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -98108,20 +97903,23 @@ tXZ
 tXZ
 tXZ
 tXZ
+ljo
+ljo
+ljo
+ljo
 tXZ
 tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -98192,13 +97990,13 @@ tXZ
 tXZ
 tXZ
 tXZ
-abW
-abW
-abW
-abW
-abW
-abW
-abW
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
 tXZ
 tXZ
 tXZ
@@ -98226,34 +98024,30 @@ tXZ
 tXZ
 tXZ
 tXZ
+ljo
+ljo
+ljo
 tXZ
 tXZ
 tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
-tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-tXZ
-tXZ
-tXZ
-tXZ
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -98266,6 +98060,10 @@ tXZ
 tXZ
 tXZ
 tXZ
+ljo
+ljo
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -98348,15 +98146,15 @@ tXZ
 tXZ
 tXZ
 tXZ
-abW
-abW
-abW
-abW
-abW
-abW
-abW
-abW
-abW
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
 tXZ
 tXZ
 tXZ
@@ -98383,6 +98181,9 @@ tXZ
 tXZ
 tXZ
 tXZ
+ljo
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -98391,24 +98192,19 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
-tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-tXZ
-tXZ
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -98421,8 +98217,10 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
+ljo
+ljo
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -98504,18 +98302,18 @@ tXZ
 tXZ
 tXZ
 tXZ
-abW
-abW
-abW
-abW
-abW
-abW
-abW
-abW
-abW
-abW
-abW
-abW
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
 tXZ
 tXZ
 tXZ
@@ -98551,19 +98349,19 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -98590,12 +98388,12 @@ tXZ
 fLF
 fLF
 fLF
-iPW
-iPW
+cij
+cij
 dMQ
-iPW
-iPW
-kDi
+cij
+cij
+qhe
 tXZ
 tXZ
 tXZ
@@ -98661,20 +98459,20 @@ tXZ
 tXZ
 tXZ
 tXZ
-abW
-abW
-abW
-abW
-abW
-abW
-abW
-abW
-abW
-abW
-abW
-abW
-tXZ
-tXZ
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -98708,11 +98506,11 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
+qhe
+qhe
+qhe
+qhe
+qhe
 tXZ
 tXZ
 tXZ
@@ -98747,12 +98545,12 @@ tXZ
 bea
 bea
 bea
-iPW
+cij
 eVW
-bRO
+acN
 ddN
-iPW
-kDi
+cij
+qhe
 tXZ
 tXZ
 tXZ
@@ -98818,20 +98616,20 @@ tXZ
 tXZ
 tXZ
 tXZ
-abW
-abW
-abW
-abW
-abW
-abW
-abW
-abW
-abW
-abW
-abW
-abW
-tXZ
-tXZ
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -98904,12 +98702,12 @@ tXZ
 bea
 bea
 bea
-iPW
-bRO
-iPW
-bRO
-iPW
-kDi
+cij
+acN
+cij
+acN
+cij
+qhe
 tXZ
 tXZ
 tXZ
@@ -98975,20 +98773,20 @@ tXZ
 tXZ
 tXZ
 tXZ
-abW
-abW
-abW
-abW
-abW
-abW
-abW
-abW
-abW
-abW
-abW
-abW
-tXZ
-tXZ
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -99061,12 +98859,12 @@ tXZ
 bea
 bea
 bea
-iPW
+cij
 oVD
-bRO
-bRO
-iPW
-kDi
+acN
+acN
+cij
+qhe
 tXZ
 tXZ
 tXZ
@@ -99132,18 +98930,18 @@ tXZ
 tXZ
 tXZ
 tXZ
-abW
-abW
-abW
-abW
-abW
-abW
-abW
-abW
-abW
-abW
-abW
-abW
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
 fam
 fam
 fam
@@ -99218,12 +99016,12 @@ tXZ
 bea
 bea
 bea
-moC
-bRO
-iPW
+abj
+acN
+cij
 wnE
-iPW
-kDi
+cij
+qhe
 tXZ
 tXZ
 tXZ
@@ -99290,15 +99088,15 @@ tXZ
 tXZ
 tXZ
 tXZ
-abW
-abW
-abW
-abW
-abW
-abW
-abW
-abW
-abW
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
 tXZ
 fam
 fam
@@ -99343,16 +99141,16 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+ljo
+ljo
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -99375,12 +99173,12 @@ tXZ
 bea
 bea
 bea
-iPW
-nCA
+cij
+gdD
 wnE
 wnE
-iPW
-kDi
+cij
+qhe
 tXZ
 tXZ
 tXZ
@@ -99448,13 +99246,13 @@ tXZ
 tXZ
 tXZ
 tXZ
-abW
-abW
-abW
-abW
-abW
-abW
-abW
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
+ktr
 tXZ
 tXZ
 fam
@@ -99500,16 +99298,16 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+ljo
+ljo
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -99532,12 +99330,12 @@ tXZ
 tXZ
 tXZ
 bea
-iPW
-acF
-acF
+cij
+gbn
+gbn
 bWc
-iPW
-kDi
+cij
+qhe
 tXZ
 tXZ
 tXZ
@@ -99606,11 +99404,11 @@ tXZ
 tXZ
 tXZ
 tXZ
-abW
-abW
-abW
-abW
-abW
+ktr
+ktr
+ktr
+ktr
+ktr
 tXZ
 tXZ
 fam
@@ -99657,16 +99455,16 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+ljo
+ljo
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -99689,12 +99487,12 @@ tXZ
 tXZ
 tXZ
 bea
-iPW
-acF
-acF
+cij
+gbn
+gbn
 bWc
-iPW
-kDi
+cij
+qhe
 tXZ
 tXZ
 tXZ
@@ -99814,16 +99612,16 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+ljo
+ljo
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -99846,12 +99644,12 @@ tXZ
 tXZ
 tXZ
 bea
-iPW
-acF
-acF
+cij
+gbn
+gbn
 bWc
-iPW
-kDi
+cij
+qhe
 tXZ
 tXZ
 tXZ
@@ -99971,16 +99769,16 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+ljo
+ljo
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -100003,12 +99801,12 @@ tXZ
 tXZ
 tXZ
 bea
-iPW
-acF
-acF
+cij
+gbn
+gbn
 bWc
-iPW
-kDi
+cij
+qhe
 tXZ
 tXZ
 tXZ
@@ -100128,16 +99926,16 @@ tXZ
 tXZ
 tXZ
 tXZ
-kDi
-kDi
-kDi
-kDi
-kDi
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
+qhe
+qhe
+qhe
+qhe
+qhe
+qhe
+ljo
+ljo
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -100160,12 +99958,12 @@ tXZ
 tXZ
 tXZ
 bea
-iPW
-acF
-acF
+cij
+gbn
+gbn
 iFl
-iPW
-kDi
+cij
+qhe
 tXZ
 tXZ
 tXZ
@@ -100317,12 +100115,12 @@ tXZ
 tXZ
 tXZ
 bea
-iPW
+cij
 loL
 wnE
-bRO
-iPW
-kDi
+acN
+cij
+qhe
 tXZ
 tXZ
 tXZ
@@ -100474,12 +100272,12 @@ tXZ
 tXZ
 tXZ
 bea
-iPW
-iPW
+cij
+cij
 wDU
-iPW
-iPW
-kDi
+cij
+cij
+qhe
 tXZ
 tXZ
 tXZ
@@ -100630,9 +100428,9 @@ gRi
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
-tXZ
+ljo
+ljo
+ljo
 ujo
 ujo
 ujo
@@ -101240,11 +101038,11 @@ fam
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
+ljo
+ljo
+ljo
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -101397,11 +101195,11 @@ fam
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
+ljo
+ljo
 dhN
-tXZ
-tXZ
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -101554,11 +101352,11 @@ fam
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
+ljo
+ljo
 dhN
-tXZ
-tXZ
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -101711,11 +101509,11 @@ fam
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
+ljo
+ljo
 dhN
-tXZ
-tXZ
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -101868,14 +101666,14 @@ fam
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
+ljo
+ljo
 dhN
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
+ljo
+ljo
+ljo
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -102025,14 +101823,14 @@ fam
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
+ljo
+ljo
 dhN
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
+ljo
+ljo
+ljo
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -102182,14 +101980,14 @@ fam
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
+ljo
+ljo
 dqJ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
+ljo
+ljo
+ljo
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -102339,14 +102137,14 @@ fam
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
+ljo
+ljo
 dqJ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
+ljo
+ljo
+ljo
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -102496,14 +102294,14 @@ fam
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
+ljo
+ljo
 dqJ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
+ljo
+ljo
+ljo
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -102653,14 +102451,14 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
+ljo
+ljo
 dqJ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
+ljo
+ljo
+ljo
+ljo
+ljo
 tXZ
 tXZ
 tXZ
@@ -102810,11 +102608,11 @@ tXZ
 tXZ
 tXZ
 tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
+ljo
+ljo
+ljo
+ljo
+ljo
 tXZ
 tXZ
 tXZ


### PR DESCRIPTION

## About The Pull Request

Correctly sets the areas of the main town map (hamlet) to "town" so that garrison / anyone with the guardsman perk gains the benefit of being in the area. Every building missing any sort of area has also, been fixed.
This is how the area currently looks like:
![image](https://github.com/user-attachments/assets/7621bb9a-e924-46b1-9f26-a6f494da6b3a)

The perk in question:
![image](https://github.com/user-attachments/assets/2f0a6a61-10ee-4a25-adfe-094342a33ee9)
![image](https://github.com/user-attachments/assets/87f0560e-9947-495a-8c47-2dc57ec0822d)

It working correctly in different areas (you can tell by the thing in the top-right):
![image](https://github.com/user-attachments/assets/d701de12-51d4-4c23-86fc-0e924ec6b64a)
![image](https://github.com/user-attachments/assets/dcdabace-58ca-403a-bf76-c00d3934f0ca)
![image](https://github.com/user-attachments/assets/f393929e-6820-4dfa-b785-6ba8ba2fee0d)


## Why It's Good For The Game

Correctly using areas is good for the game! Not only do we get to hear soundtracks we would've (otherwise) never heard before, but garrison now, actually, gets the buff they should've gotten from guarding their little hamlet.
