### PR TITLE
Unlocks Smithy Entrance

### DIFF
--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -9301,6 +9301,12 @@
 /obj/structure/closet/crate/roguecloset/inn,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town)
+"rRx" = (
+/obj/structure/mineral_door/wood/towner/blacksmith{
+	locked = 0
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town)
 "rRK" = (
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/town)
@@ -48549,7 +48555,7 @@ uSv
 bWc
 acN
 acN
-cty
+rRx
 iSL
 iSL
 tjx


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Just makes the front door unlocked on round start. Lets yeomen smiths and artificers have their own space, but if they arent around, people can still access steel and bronze.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
