### PR TITLE
Salt and Goodberry

### DIFF
--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -9301,6 +9301,12 @@
 /obj/structure/closet/crate/roguecloset/inn,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town)
+"rRx" = (
+/obj/structure/mineral_door/wood/towner/blacksmith{
+	locked = 0
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town)
 "rRK" = (
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/town)
@@ -48549,7 +48555,7 @@ uSv
 bWc
 acN
 acN
-cty
+rRx
 iSL
 iSL
 tjx

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -45,8 +45,8 @@
 #endif								//	1 to use the default behaviour;
 									//	2 for preloading absolutely everything;
 
-#define LOWMEMORYMODE //uncomment this to load centcom and roguetest and thats it.
-
+/* #define LOWMEMORYMODE //uncomment this to load centcom and roguetest and thats it. // (Seriously, dont uncomment this if youre testing. Just untick roguetest's forcemap file.)
+ */
 #ifdef LOWMEMORYMODE
 #define FORCE_MAP "_maps/runtimestation.json"
 #endif

--- a/code/modules/roguetown/roguejobs/cook/tools/grinding.dm
+++ b/code/modules/roguetown/roguejobs/cook/tools/grinding.dm
@@ -24,7 +24,7 @@
 			new /obj/item/reagent_containers/powder/mineral(get_turf(loc))
 			qdel(W)
 		return
-	if(istype(W, /obj/item/reagent_containers/powder/coarse_salt))
+	if(istype(W, /obj/item/reagent_containers/powder/mineral))
 		playsound(get_turf(user), 'modular/Neu_Food/sound/milling.ogg', 100, TRUE, -1)
 		if(do_after(user, 10, target = src))
 			new /obj/item/reagent_containers/powder/salt(get_turf(loc))

--- a/code/modules/spells/roguetown/spells5e/cantrips5e.dm
+++ b/code/modules/spells/roguetown/spells5e/cantrips5e.dm
@@ -1327,6 +1327,73 @@
 
 /datum/status_effect/buff/healing_weave/on_remove()
 	owner.remove_filter(MIRACLE_HEALING_FILTER)
+
+//==============================================
+//	RESISTANCE
+//==============================================
+
+/obj/effect/proc_holder/spell/self/goodberry
+	name = "Goodberry"
+	overlay_state = "null"
+	releasedrain = 50
+	chargetime = 1
+	charge_max = 30 SECONDS
+	range = 2
+	warnie = "spellwarning"
+	movement_interrupt = FALSE
+	no_early_release = FALSE
+	chargedloop = null
+	sound = 'sound/magic/whiteflame.ogg'
+	chargedloop = /datum/looping_sound/invokegen
+	associated_skill = /datum/skill/magic/arcane //can be arcane, druidic, blood, holy
+	cost = 2 // Theoretically infinite healing. 
+
+	xp_gain = TRUE
+	miracle = FALSE
+
+	invocation = "Nutrire!"
+	invocation_type = "shout" //can be none, whisper, emote and shout
+
+	var/obj/item/item
+	var/item_type = /obj/item/reagent_containers/food/snacks/grown/berries/rogue/goodberry
+	var/delete_old = FALSE //TRUE to delete the last summoned object if it's still there, FALSE for infinite item stream weeeee
+
+/obj/effect/proc_holder/spell/self/goodberry/cast(list/targets, mob/user = usr)
+	var/obj/item/goodberry = user.get_active_held_item()
+	if(!istype(goodberry, /obj/item/reagent_containers/food/snacks/grown/berries/rogue))
+		user.visible_message(span_warning("I require some berries in a free hand."))
+	else
+		qdel(goodberry)
+		if (delete_old && item && !QDELETED(item))
+			QDEL_NULL(item)
+		if(user.dropItemToGround(user.get_active_held_item()))
+			user.put_in_hands(make_item(), TRUE)
+			user.visible_message(span_info("The weave condenses into the berries in [user]'s hand!"), span_info("You magically charge the berries!"))
+			return
+
+/obj/effect/proc_holder/spell/self/goodberry/proc/make_item()
+	item = new item_type
+	return item
+
+/obj/item/reagent_containers/food/snacks/grown/berries/rogue/goodberry
+	seed = /obj/item/seeds/berryrogue
+	name = "Goodberries"
+	desc = "Plump, sweet berries charged with the weave. Eat them soon, before they lose their magic!"
+	icon_state = "berries"
+	color = "#d9f075"
+	tastes = list("berry" = 1, "arcane healing" = 1)
+	bitesize = 5
+	list_reagents = list(
+		/datum/reagent/consumable/nutriment = 6,
+		/datum/reagent/medicine/stronghealth = 3
+		)
+	faretype = FARE_NEUTRAL
+	dropshrink = 0.75
+	can_distill = TRUE
+	distill_reagent = /datum/reagent/medicine/healthpotnew
+	rotprocess = 30 SECONDS // Lasts 5 minutes 30 seconds upon creation.
+	become_rot_type = /obj/item/reagent_containers/food/snacks/grown/berries/rogue
+
 //==============================================
 //	RESISTANCE
 //==============================================

--- a/modular/Neu_Food/code/NeuFood.dm
+++ b/modular/Neu_Food/code/NeuFood.dm
@@ -459,7 +459,7 @@
 	..()
 	qdel(src)
 
-/obj/item/reagent_containers/powder/mineral/attackby(obj/item/I, mob/user, params)
+/* /obj/item/reagent_containers/powder/mineral/attackby(obj/item/I, mob/user, params)
 	var/found_table = locate(/obj/structure/table) in (loc)
 	var/obj/item/reagent_containers/R = I
 	if(user.mind)
@@ -492,7 +492,7 @@
 				new /obj/item/reagent_containers/powder/coarse_salt(loc)
 				qdel(src)
 	else ..()
-
+ */
 
 /*	..................   Food platter   ................... */
 /obj/item/cooking/platter/attackby(obj/item/I, mob/user, params)

--- a/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
+++ b/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
@@ -231,6 +231,7 @@
 		/obj/effect/proc_holder/spell/invoked/greenflameblade5e,
 		/obj/effect/proc_holder/spell/invoked/infestation5e,
 		/obj/effect/proc_holder/spell/self/light5e,
+		/obj/effect/proc_holder/spell/self/goodberry,
 		/obj/effect/proc_holder/spell/targeted/lightninglure5e,
 		/obj/effect/proc_holder/spell/invoked/projectile/rayoffrost5e,
 		/obj/effect/proc_holder/spell/invoked/snap_freeze,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Adds goodberry spell to arcane casting! Can be modified for miracles later, or made into a druid exclusive, if desired.
Requires jacksberries in hand to make, and they lose their magic after five minutes, returning to normal jacksberries.
Costs 2 spell points as they provide decent healing and can be benefited from by people who cannot be healed by cure wounds, on top of being able to be processed in multiple ways for healing uses.

Makes salt easier to get as well. Grind stone, then grind the coarse minerals.

Also makes it possible to use the test map again.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
