### PR TITLE
Vampiric Prowess Virtue Flavor Update

### DIFF
--- a/modular_azurepeak/virtues/utility.dm
+++ b/modular_azurepeak/virtues/utility.dm
@@ -66,6 +66,8 @@
 	added_traits = list(TRAIT_NOHUNGER, TRAIT_NOBREATH, TRAIT_ZJUMP, TRAIT_NOFALLDAMAGE1, TRAIT_EASYDISMEMBER, TRAIT_DARKLING, TRAIT_VAMPIRIC_CURSE)
 
 /datum/virtue/utility/deathless/apply_to_human(mob/living/carbon/human/recipient)
+	added_skills = list(list(/datum/skill/magic/blood, 2, 3) // Adding 2 ranks, to a max of 3. The original code that gives the below spells assumes you have this at the least beforehand. Doesnt actually do anything unless you have transfix, which this trait does not give.
+	)
 	recipient.mind?.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/bloodlightning)
 	recipient.mind?.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/bloodsteal)
 	recipient.mind?.AddSpell(new /obj/effect/proc_holder/spell/targeted/shapeshift/bat)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Just gives 2 levels of blood magic to the holder. This will do nothing unless you have transfix, which Vampiric Prowess does not give.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes sense that the characters with blood steal and blood bolt should know minor blood sorcery. Could probably have the skills govern those spells in some way at some point.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
