### PR TITLE
Wild Night Flaw Tweak

### DIFF
--- a/_maps/map_files/dun_manor/UnderHotenow.dmm
+++ b/_maps/map_files/dun_manor/UnderHotenow.dmm
@@ -1024,6 +1024,14 @@
 /obj/item/storage/belt/rogue/pouch/coins/mid,
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/underdark/harrowhall)
+"to" = (
+/obj/effect/landmark/start/adventurerlate{
+	dir = 1
+	},
+/turf/open/floor/rogue/dirt/road{
+	color = "585F96"
+	},
+/area/rogue/under/underdark)
 "tu" = (
 /mob/living/carbon/human/species/elf/dark/npc/basic/ambush,
 /turf/open/floor/rogue/ruinedwood,
@@ -2693,6 +2701,14 @@
 	color = "585F96"
 	},
 /area/rogue/under/underdark)
+"XS" = (
+/obj/effect/landmark/start/adventurerlate{
+	dir = 1
+	},
+/turf/open/floor/rogue/dirt{
+	color = "585F96"
+	},
+/area/rogue/under/underdark)
 "Yf" = (
 /obj/effect/decal/mossy{
 	dir = 1
@@ -4239,7 +4255,7 @@ BO
 BO
 BO
 gT
-gT
+XS
 gT
 gT
 gT
@@ -11285,7 +11301,7 @@ gT
 gT
 Ik
 gT
-gT
+XS
 pT
 pT
 pT
@@ -11402,7 +11418,7 @@ Im
 vr
 gT
 gT
-gT
+XS
 gT
 gT
 gv
@@ -11936,7 +11952,7 @@ Ik
 gT
 Ik
 gT
-gT
+XS
 pT
 pT
 pT
@@ -14277,7 +14293,7 @@ Ik
 Ik
 Ik
 Ik
-Ik
+to
 Ik
 Ik
 gT
@@ -17648,7 +17664,7 @@ Ik
 gT
 Ik
 Ik
-Ik
+to
 Ik
 gT
 Ik
@@ -18009,7 +18025,7 @@ gT
 Ik
 Ik
 Ik
-Ik
+to
 Ik
 Ik
 Ik
@@ -24823,7 +24839,7 @@ yH
 BO
 BO
 BO
-Ik
+to
 Ik
 Ky
 Fk
@@ -32611,7 +32627,7 @@ BO
 Fk
 Fk
 aO
-Ik
+to
 Ik
 BO
 yH
@@ -37044,7 +37060,7 @@ yH
 BO
 BO
 gT
-gT
+XS
 Ik
 gT
 gT
@@ -37065,7 +37081,7 @@ gT
 Ik
 gT
 gT
-gT
+XS
 gT
 gT
 Ik
@@ -40975,7 +40991,7 @@ gT
 gT
 gT
 gT
-gT
+XS
 gT
 gT
 gT
@@ -47033,7 +47049,7 @@ gT
 Ik
 gT
 gT
-gT
+XS
 Ik
 gT
 gT
@@ -49226,7 +49242,7 @@ Ik
 gT
 gT
 gT
-gT
+XS
 gT
 ZA
 sT
@@ -50744,7 +50760,7 @@ gT
 gT
 Ik
 gT
-gT
+XS
 gT
 Ik
 gT
@@ -51375,7 +51391,7 @@ BO
 gT
 gT
 Ik
-gT
+XS
 gT
 gT
 gT

--- a/_maps/map_files/dun_manor/azure_coast.dmm
+++ b/_maps/map_files/dun_manor/azure_coast.dmm
@@ -947,6 +947,12 @@
 /mob/living/carbon/human/species/skeleton/npc/ambush,
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/beach)
+"fh" = (
+/obj/effect/landmark/start/adventurerlate{
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/beach/forest)
 "fi" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/orc,
 /turf/open/floor/rogue/cobble,
@@ -1241,6 +1247,14 @@
 	icon_state = "weird1"
 	},
 /area/rogue/outdoors/beach/forest)
+"hh" = (
+/obj/effect/landmark/start/adventurerlate{
+	dir = 1
+	},
+/turf/open/floor/rogue/snow{
+	color = "e6f2ff"
+	},
+/area/rogue/outdoors/beach/forest)
 "hj" = (
 /obj/structure/glowshroom,
 /turf/open/water/swamp,
@@ -1449,6 +1463,14 @@
 /obj/item/clothing/neck/roguetown/psicross,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/beach/forest)
+"iY" = (
+/obj/effect/landmark/start/adventurerlate{
+	dir = 1
+	},
+/turf/open/floor/rogue/dirt/road{
+	color = "80ffff"
+	},
+/area/rogue/outdoors/beach)
 "iZ" = (
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/rogue/cobble/mossy,
@@ -2161,6 +2183,12 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/cave)
+"oT" = (
+/obj/effect/landmark/start/adventurerlate{
+	dir = 1
+	},
+/turf/open/floor/rogue/grasscold,
+/area/rogue/outdoors/beach/forest)
 "oX" = (
 /turf/closed/wall/mineral/rogue/tent{
 	dir = 1
@@ -3646,6 +3674,12 @@
 "Ad" = (
 /turf/open/water/swamp,
 /area/rogue/indoors/cave)
+"Ah" = (
+/obj/effect/landmark/start/adventurerlate{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/outdoors/beach/forest)
 "Ai" = (
 /obj/structure/fluff/statue/small,
 /turf/open/floor/rogue/blocks,
@@ -4921,6 +4955,12 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/cave)
+"JD" = (
+/obj/effect/landmark/start/adventurerlate{
+	dir = 1
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/outdoors/beach/forest)
 "JE" = (
 /obj/structure/fermenting_barrel,
 /turf/open/floor/rogue/cobble,
@@ -36851,7 +36891,7 @@ Xd
 Xd
 Xd
 Xd
-Xd
+iY
 Xd
 Xd
 Xd
@@ -37120,7 +37160,7 @@ Xd
 Xd
 Xd
 Xd
-Xd
+iY
 Xd
 Xd
 Xd
@@ -37259,7 +37299,7 @@ Xd
 Xd
 Xd
 Xd
-Xd
+iY
 Xd
 Xd
 Xd
@@ -51018,7 +51058,7 @@ mK
 lI
 pa
 lI
-lI
+fh
 lI
 pa
 pa
@@ -58327,7 +58367,7 @@ XK
 XK
 bu
 pa
-pa
+oT
 pa
 pa
 pz
@@ -60472,7 +60512,7 @@ ub
 ub
 BA
 oJ
-oJ
+Ah
 oJ
 BA
 BA
@@ -62493,7 +62533,7 @@ BA
 BA
 BA
 pz
-pz
+hh
 pz
 pZ
 "}
@@ -65790,7 +65830,7 @@ AX
 AX
 AX
 AX
-AX
+JD
 AX
 AX
 AX

--- a/_maps/map_files/dun_manor/azure_forest.dmm
+++ b/_maps/map_files/dun_manor/azure_forest.dmm
@@ -369,6 +369,12 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/woods)
+"cQ" = (
+/obj/effect/landmark/start/adventurerlate{
+	dir = 1
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/woods)
 "cR" = (
 /obj/effect/decal/cobbleedge,
 /obj/effect/decal/cobbleedge{
@@ -599,6 +605,16 @@
 "eD" = (
 /obj/structure/flora/roguegrass/water,
 /turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/woods)
+"eE" = (
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	icon_state = "border"
+	},
+/obj/effect/landmark/start/adventurerlate{
+	dir = 1
+	},
+/turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/woods)
 "eG" = (
 /obj/machinery/light/rogue/campfire/densefire,
@@ -1039,6 +1055,15 @@
 	lockid = "fuckshack"
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/outdoors/woods)
+"hN" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/effect/landmark/start/adventurerlate{
+	dir = 1
+	},
+/turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/woods)
 "hP" = (
 /obj/structure/chair/bench/couchablack,
@@ -5255,6 +5280,12 @@
 /obj/structure/flora/roguegrass/water,
 /turf/open/water/pond,
 /area/rogue/outdoors/woods)
+"Ql" = (
+/obj/effect/landmark/start/adventurerlate{
+	dir = 1
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/outdoors/woods)
 "Qm" = (
 /obj/item/natural/stone,
 /turf/open/floor/rogue/naturalstone,
@@ -5498,6 +5529,12 @@
 /area/rogue/outdoors/woods)
 "Si" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/mudcrab,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/woods)
+"Sk" = (
+/obj/effect/landmark/start/adventurerlate{
+	dir = 1
+	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/woods)
 "So" = (
@@ -33217,7 +33254,7 @@ kV
 jW
 jW
 jW
-jW
+bS
 jW
 jW
 jW
@@ -33684,7 +33721,7 @@ jW
 jW
 jW
 By
-jW
+bS
 bP
 bP
 bP
@@ -35396,7 +35433,7 @@ Vh
 Vh
 Vh
 Vh
-jW
+bS
 jW
 bP
 bP
@@ -44080,7 +44117,7 @@ MK
 MK
 MK
 Yi
-Yi
+cQ
 Yi
 BP
 SS
@@ -45008,7 +45045,7 @@ Lv
 lq
 bN
 MK
-MK
+kf
 MK
 MK
 ZC
@@ -45314,7 +45351,7 @@ bP
 bP
 jW
 zA
-zA
+Ql
 MK
 MK
 MK
@@ -45798,7 +45835,7 @@ Yi
 MK
 MK
 MK
-MK
+kf
 MK
 MK
 MK
@@ -46711,7 +46748,7 @@ bP
 SA
 Vh
 Nz
-Vh
+Sk
 SA
 jW
 MK
@@ -49030,7 +49067,7 @@ bP
 in
 Yi
 Vh
-Yi
+cQ
 Yi
 Vh
 pC
@@ -49501,7 +49538,7 @@ jW
 in
 MK
 Yi
-jW
+bS
 Yi
 Yi
 FM
@@ -49972,7 +50009,7 @@ MK
 MK
 Yi
 Yi
-MK
+kf
 jW
 Vh
 pC
@@ -51370,7 +51407,7 @@ rk
 rk
 rk
 rk
-rk
+eE
 hp
 Uy
 Yi
@@ -51524,7 +51561,7 @@ ik
 zM
 iq
 iq
-iq
+hN
 iq
 iq
 iq

--- a/modular_stonehedge/code/datums/traits/unspecial.dm
+++ b/modular_stonehedge/code/datums/traits/unspecial.dm
@@ -669,7 +669,7 @@
 /datum/quirk/wild_night
 	name = "(Flaw) Wild Night"
 	desc = "I don't remember what I did last night, and now I'm lost!"
-	value = -8
+	value = -15
 
 /datum/quirk/wild_night/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Increases the points you get from 8 to 15 for taking it BUT
Adds around three half-dozen new spots in variably dangerous locations to justify this flaw being expensive to begin with. Anywhere from the southern woods, to the far coast, to deep down beneath in the underdark. You're gambling with your life, here, taking this! Be sure you want the challenge.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Quirk didnt really feel like it justified even 8 points, but 8 points doesnt feel like enough for adding random spawn locations for those who take it. This will make it another one of those high risk high reward traits. If you die because of where the dice fell, that's on you!
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
