### PR TITLE
Buffs Create Bonfire

### DIFF
--- a/code/modules/spells/roguetown/spells5e/cantrips5e.dm
+++ b/code/modules/spells/roguetown/spells5e/cantrips5e.dm
@@ -206,7 +206,7 @@
 	summon_type = list(
 		/obj/machinery/light/rogue/campfire/createbonfire5e
 	)
-	summon_lifespan = 600
+	summon_lifespan = 10 MINUTES
 	summon_amt = 1
 
 	action_icon_state = "the_traps"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Compared to other spells, this one is actually quite poor when it comes to combat. The only true utility it has beyond that is the fact it can be used as a cooking source, as well as a light source for small encampments. I think it really shines in the underdark! Pun intended.

So I feel increasing the summon from 1 minute to 10 minutes is reasonable, since even NPCs automatically extinguish themselves, so it doesnt really do you favors in combat. The 1 minute timer was there as a direct translation from dnd, but in actual dnd, 1 minute can be an entire combat encounter, whereas here it takes several.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
