### PR TITLE
This probably fixes arm markings

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -31,13 +31,13 @@
 #define LEG_DAMAGE_LAYER		35
 #define LEGSLEEVE_LAYER			34
 #define SHOESLEEVE_LAYER		33
-#define SHIRT_LAYER				32
-#define WRISTS_LAYER			31
-#define ARMOR_LAYER				30
-#define TABARD_LAYER			29
-#define BELT_LAYER				28		//only when looking south
-#define UNDER_CLOAK_LAYER		27
-#define HANDS_PART_LAYER		26
+#define HANDS_PART_LAYER		32
+#define SHIRT_LAYER				31
+#define WRISTS_LAYER			30
+#define ARMOR_LAYER				29
+#define TABARD_LAYER			28
+#define BELT_LAYER				27		//only when looking south
+#define UNDER_CLOAK_LAYER		26
 #define GLOVES_LAYER			25
 #define ARM_DAMAGE_LAYER		24
 #define SHIRTSLEEVE_LAYER		23


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Perusing the code, it seems that bigger number means underneath smaller number
Armor, shirts, etc used a higher value than the arms did for visual layering, this pr slides the arm layer 'above' the shirt layer, which causes shirts and such to hide arm layers now, finally.

I didnt see any other affected things by this, so this should be perfectly fine.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
