### PR TITLE
Fixes Big Health Potion's Recipe

### DIFF
--- a/code/modules/roguetown/roguecrafting/alchemy/cauldron_recipes.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/cauldron_recipes.dm
@@ -48,7 +48,7 @@
 /datum/alch_cauldron_recipe/big_health_potion
 	recipe_name = "Strong Elixir of Health"
 	smells_like = "lifeblood"
-	output_reagents = list(/datum/reagent/medicine/stronghealth = 81,/datum/reagent/additive = 81)
+	output_reagents = list(/datum/reagent/medicine/healthpot = 81,/datum/reagent/additive = 81)
 
 /datum/alch_cauldron_recipe/rosewater_potion
 	recipe_name = "Rose Water"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Issue with the mix was it created bighealthpot and additive instead of healthpot and additive, which mix to make the bighealthpot reagent as intended.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
