### PR TITLE
Fixes Second Wind Usage

### DIFF
--- a/code/modules/spells/roguetown/fighter.dm
+++ b/code/modules/spells/roguetown/fighter.dm
@@ -27,7 +27,7 @@
 	miracle = FALSE
 
 	invocation = ""
-	invocation_type = "shout" //can be none, whisper, emote and shout
+	invocation_type = "emote" //can be none, whisper, emote and shout
 
 /obj/effect/proc_holder/spell/self/secondwind/cast(mob/user = usr)
 	var/mob/living/carbon/M = user


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Being gagged seems to prevent the ability from being used. Such as being horizontal in water.
Swapped it from being a shout invocation to an emote invocation, keeping its flavor and making it possible to use when your mouth is covered.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
