### PR TITLE
Tongs bagspace usage lowered

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/tools.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/tools.dm
@@ -190,6 +190,8 @@
 	var/obj/item/ingot/hingot = null
 	var/hott = FALSE
 	smeltresult = /obj/item/ingot/iron
+	grid_width = ONE_SLOTS
+	grid_height = TWO_SLOTS
 
 
 /obj/item/rogueweapon/tongs/examine(mob/user)


### PR DESCRIPTION
For some rediculous reason it took up a giant square of space compared to a hammer. Now it's about the same as a regular blacksmiths hammer. This applies to all tongs.